### PR TITLE
Fix repeated log loading state

### DIFF
--- a/src/components/Attestation/Create.tsx
+++ b/src/components/Attestation/Create.tsx
@@ -74,7 +74,8 @@ export const CreateAttestation: FC<Props> = ({ onAttestationCreated }) => {
       if (isDisabled) return;
       setIsLoading(true);
       try {
-        // Reset the transaction resolution state for new logs
+        // Reset state for new logs
+        setTransactionId(undefined);
         setIsTransactionIdResolved(false);
         // Call the backend tRPC procedure
         const transactionId = await logHotdog({


### PR DESCRIPTION
## Summary
- clear previous transaction id before starting a new log so the loading state triggers correctly

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_684dd90e0d14833188102d73d3c92959