### PR TITLE
Add Farcaster share prompt after logging a dog

### DIFF
--- a/src/components/Attestation/Create.tsx
+++ b/src/components/Attestation/Create.tsx
@@ -209,8 +209,8 @@ export const CreateAttestation: FC<Props> = ({ onAttestationCreated }) => {
           errorMessage="Failed to log your dog"
         />
       )}
-      <dialog id="share_cast_modal" className="modal">
-        <div className="modal-box">
+      <dialog id="share_cast_modal" className="modal modal-bottom sm:modal-middle">
+        <div className="modal-box bg-opacity-50 backdrop-blur-lg">
           <h3 className="font-bold text-lg">Share on Farcaster?</h3>
           <p className="py-4">Would you like to share your logged dog on Farcaster?</p>
           <div className="modal-action">


### PR DESCRIPTION
## Summary
- prompt Farcaster users to share a dog log
- allow composing a cast with the uploaded image when confirmed

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install --legacy-peer-deps` *(fails: network access blocked for binaries.prisma.sh)*

------
https://chatgpt.com/codex/tasks/task_e_684ddad19cec833189db4559ff919c1d