### PR TITLE
Clean up DebugInfo events

### DIFF
--- a/contracts/src/LogADog.sol
+++ b/contracts/src/LogADog.sol
@@ -46,7 +46,6 @@ contract LogADog is AccessControl {
     event OperatorAdded(address indexed operator);
     event OperatorRemoved(address indexed operator);
 
-    event DebugInfo(uint256 msgValue, uint256 contractBalance);
 
     modifier onlyLogOwner(uint256 logId) {
         require(hotdogLogs[logId].eater == msg.sender, "Caller is not the owner of this log");
@@ -106,7 +105,6 @@ contract LogADog is AccessControl {
     function _logHotdog(string memory imageUri, string memory metadataUri, string memory coinUri, address eater, bytes calldata poolConfig) internal returns (uint256 logId) {
         logId = hotdogLogs.length;
         
-        emit DebugInfo(msg.value, address(this).balance);
 
         // Deploy coin using CoinDeploymentManager
         address coinAddress;

--- a/src/thirdweb/84532/0x0884d4aa36d1bf4f3cc21288d1fca6dad8fed46b.ts
+++ b/src/thirdweb/84532/0x0884d4aa36d1bf4f3cc21288d1fca6dad8fed46b.ts
@@ -85,29 +85,6 @@ export function attestationRevokedEvent(filters: AttestationRevokedEventFilters 
 
 
 /**
- * Creates an event object for the DebugInfo event.
- * @returns The prepared event object.
- * @example
- * ```
- * import { getContractEvents } from "thirdweb";
- * import { debugInfoEvent } from "TODO";
- *
- * const events = await getContractEvents({
- * contract,
- * events: [
- *  debugInfoEvent()
- * ],
- * });
- * ```
- */
-export function debugInfoEvent() {
-  return prepareEvent({
-    signature: "event DebugInfo(uint256 msgValue, uint256 contractBalance)",
-  });
-};
-  
-
-/**
  * Represents the filters for the "HotdogLogRevoked" event.
  */
 export type HotdogLogRevokedEventFilters = Partial<{

--- a/src/thirdweb/84532/0x0b04ceb7542cc13e0e483e7b05907c31dbee4d7f.ts
+++ b/src/thirdweb/84532/0x0b04ceb7542cc13e0e483e7b05907c31dbee4d7f.ts
@@ -85,29 +85,6 @@ export function attestationRevokedEvent(filters: AttestationRevokedEventFilters 
 
 
 /**
- * Creates an event object for the DebugInfo event.
- * @returns The prepared event object.
- * @example
- * ```
- * import { getContractEvents } from "thirdweb";
- * import { debugInfoEvent } from "TODO";
- *
- * const events = await getContractEvents({
- * contract,
- * events: [
- *  debugInfoEvent()
- * ],
- * });
- * ```
- */
-export function debugInfoEvent() {
-  return prepareEvent({
-    signature: "event DebugInfo(uint256 msgValue, uint256 contractBalance)",
-  });
-};
-  
-
-/**
  * Represents the filters for the "HotdogLogRevoked" event.
  */
 export type HotdogLogRevokedEventFilters = Partial<{

--- a/src/thirdweb/84532/0x71a3406e8a04ec52b7f7acce94c93f7a48fbf2c9.ts
+++ b/src/thirdweb/84532/0x71a3406e8a04ec52b7f7acce94c93f7a48fbf2c9.ts
@@ -85,29 +85,6 @@ export function attestationRevokedEvent(filters: AttestationRevokedEventFilters 
 
 
 /**
- * Creates an event object for the DebugInfo event.
- * @returns The prepared event object.
- * @example
- * ```
- * import { getContractEvents } from "thirdweb";
- * import { debugInfoEvent } from "TODO";
- *
- * const events = await getContractEvents({
- * contract,
- * events: [
- *  debugInfoEvent()
- * ],
- * });
- * ```
- */
-export function debugInfoEvent() {
-  return prepareEvent({
-    signature: "event DebugInfo(uint256 msgValue, uint256 contractBalance)",
-  });
-};
-  
-
-/**
  * Represents the filters for the "HotdogLogRevoked" event.
  */
 export type HotdogLogRevokedEventFilters = Partial<{


### PR DESCRIPTION
## Summary
- remove `DebugInfo` event from LogADog contract
- delete generated `debugInfoEvent` helper from Thirdweb wrappers

## Testing
- `forge test -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e2ee1fbe88331b5d502d2d4946d3d