### PR TITLE
Add voting countdown help modal

### DIFF
--- a/src/components/Attestation/VotingCountdown.tsx
+++ b/src/components/Attestation/VotingCountdown.tsx
@@ -161,7 +161,7 @@ export const VotingCountdown: FC<Props> = ({
             <p className="py-2">The countdown timer is how long you have to judge whether or not the hotdog is valid or not.</p>
             <p className="py-2">Users moderate each other by judging if an uploaded photo should count towards the contest or not. This prevents duplicates, fakes, and other spam.</p>
             <p className="py-2">To keep users honest, they stake $HOTDOG tokens. If their judgement aligns with the majority of other judgements, they earn a portion of $HOTDOG tokens from voters who judged incorrectly.</p>
-            <p className="py-2">Once the timer is over, nobody can vote on this submission anymore and if the submission received more yes's than no's, it counts towards the total.</p>
+            <p className="py-2">Once the timer is over, nobody can vote on this submission anymore and if the submission received more yes&apos;s than no&apos;s, it counts towards the total.</p>
             <div className="modal-action">
               <label htmlFor={id} className="btn">Close</label>
             </div>

--- a/src/components/Stake/ClaimRewards.tsx
+++ b/src/components/Stake/ClaimRewards.tsx
@@ -1,4 +1,4 @@
-import { FC, useContext } from "react";
+import { type FC, useContext } from "react";
 import { useSession } from "next-auth/react";
 import { TransactionButton, useActiveWallet, useReadContract } from "thirdweb/react";
 import { getContract } from "thirdweb";

--- a/src/pages/api/og/[logId].tsx
+++ b/src/pages/api/og/[logId].tsx
@@ -141,16 +141,19 @@ export default async function handler(req: NextRequest) {
           fontFamily: 'Segment',
         }}
       >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
         <img src={convertIpfsToHttp(hotdog.imageUri)} style={{ objectFit: 'cover', width: '1200px', height: '800px', position: 'absolute', top:0, left:0 }} />
         
         {/* Log a Dog title in upper left */}
         <div style={{ position: 'absolute', top: 20, left: 20, display:'flex', alignItems:'center', gap:12, background:'rgba(0,0,0,0.5)', padding:'12px 20px', borderRadius:12 }}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img src={`${base}/images/logo.png`} width="40" height="40" style={{ borderRadius: '4px' }} />
           <div style={{ fontSize: 36, display: 'flex', fontFamily: 'Segment' }}>Log a Dog</div>
         </div>
 
         {/* Username in bottom right */}
         <div style={{ position: 'absolute', bottom: 20, right: 20, display:'flex', alignItems:'center', gap:16, background:'rgba(0,0,0,0.5)', padding:'12px 20px', borderRadius:12 }}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img src={convertIpfsToHttp(avatar)} width="64" height="64" style={{ borderRadius: '50%' }} />
           <div style={{ display:'flex', flexDirection:'column' }}>
             <div style={{ fontSize: 36, display: 'flex', fontFamily: 'Segment' }}>{username}</div>


### PR DESCRIPTION
## Summary
- add question mark next to countdown timer
- show modal explaining how voting works and why timer matters

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e300a90ec8331a69327d77b937de4