### PR TITLE
Fix resolved status check

### DIFF
--- a/src/components/Attestation/VotingCountdown.tsx
+++ b/src/components/Attestation/VotingCountdown.tsx
@@ -86,7 +86,8 @@ export const VotingCountdown: FC<Props> = ({
   const totalVotes = Number(validAttestations ?? 0) + Number(invalidAttestations ?? 0);
   
   // Check if the attestation period is resolved using the cached data
-  const isResolved = attestationPeriod?.status === 2; // Assuming status 2 means resolved
+  // AttestationStatus enum: 0 = Active, 1 = Resolved, 2 = Disputed
+  const isResolved = attestationPeriod?.status === 1;
   
   const handleRewardModerators = () => {
     if (!logId || !session?.user?.address || !activeChain) return;


### PR DESCRIPTION
## Summary
- hide reward moderators button when attestation period status is Resolved

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: ERESOLVE unable to resolve dependency tree)*

------
https://chatgpt.com/codex/tasks/task_e_684ed524349c8331a822d137ee411039