### PR TITLE
Centralize attestation window constant

### DIFF
--- a/src/components/Attestation/List.tsx
+++ b/src/components/Attestation/List.tsx
@@ -18,7 +18,7 @@ import { formatAbbreviatedFiat } from "~/helpers/formatFiat";
 import dynamic from "next/dynamic";
 const ZoraCoinTrading = dynamic(() => import("~/components/Attestation/ZoraCoinTrading"), { ssr: false });
 
-const ATTESTATION_WINDOW_SECONDS = 48 * 60 * 60; // 48 hours
+import { ATTESTATION_WINDOW_SECONDS } from "~/constants";
 
 type Props = {
   attestors?: string[];

--- a/src/components/Attestation/VotingCountdown.tsx
+++ b/src/components/Attestation/VotingCountdown.tsx
@@ -10,6 +10,7 @@ import { QuestionMarkCircleIcon, XMarkIcon, GiftIcon } from "@heroicons/react/24
 import { Portal } from "~/components/utils/Portal";
 import { api } from "~/utils/api";
 import { toast } from "react-toastify";
+import { ATTESTATION_WINDOW_SECONDS } from "~/constants";
         
 interface Props {
   timestamp: string; // unix timestamp in seconds
@@ -29,7 +30,6 @@ interface Props {
   };
 }
 
-const ATTESTATION_WINDOW_SECONDS = 48 * 60 * 60; // 48 hours
 
 export const VotingCountdown: FC<Props> = ({
   timestamp,

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -13,3 +13,5 @@ export const APP_NAME = "Log a Dog";
 export const APP_DESCRIPTION = `Earn money eating hotdogs`;
 
 export const DEFAULT_UPLOAD_PHRASE = '📷 Take a picture of you eating it!';
+
+export const ATTESTATION_WINDOW_SECONDS = 48 * 60 * 60; // 48 hours

--- a/src/pages/dog/DogPageComponent.tsx
+++ b/src/pages/dog/DogPageComponent.tsx
@@ -22,10 +22,9 @@ import { env } from "~/env";
 import { isAddressEqual } from "viem";
 import { formatAbbreviatedFiat } from "~/helpers/formatFiat";
 import dynamic from "next/dynamic";
+import { ATTESTATION_WINDOW_SECONDS } from "~/constants";
 
 const ZoraCoinTrading = dynamic(() => import("~/components/Attestation/ZoraCoinTrading"), { ssr: false });
-
-const ATTESTATION_WINDOW_SECONDS = 48 * 60 * 60; // 48 hours
 
 const DogPage: NextPage<{ logId: string }> = ({ logId }) => {
   const account = useActiveAccount();


### PR DESCRIPTION
## Summary
- export `ATTESTATION_WINDOW_SECONDS` from constants
- use the shared constant across attestation components and pages

## Testing
- `bun install` *(fails: binaries.prisma.sh blocked)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee5df11e08331aa2c11d5869cec17