### PR TITLE
Update leaderboard logic

### DIFF
--- a/src/server/api/routers/hotdog.ts
+++ b/src/server/api/routers/hotdog.ts
@@ -687,10 +687,11 @@ export const hotdogRouter = createTRPCRouter({
         const userCounts = new Map<string, number>();
 
         for (let i = 0; i < filteredLogs.length; i++) {
-          const log = filteredLogs[i];
-          const period = attestationPeriods.get(logIds[i]);
-          const valid = attestationCounts[0][i];
-          const invalid = attestationCounts[1][i];
+          const log = filteredLogs[i]!;
+          const logId = logIds[i]!;
+          const period = attestationPeriods.get(logId);
+          const valid = attestationCounts[0][i]!;
+          const invalid = attestationCounts[1][i]!;
 
           if (!period) continue;
           const windowEnded = Number(period.endTime) <= now;


### PR DESCRIPTION
## Summary
- filter logs in leaderboard by attestation outcome

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee7557918833195ae5ce819ae5962