### PR TITLE
Hide name and verified badge from profile icon in bottom nav

### DIFF
--- a/src/components/Profile/Button.tsx
+++ b/src/components/Profile/Button.tsx
@@ -26,8 +26,9 @@ type Props = {
   loginBtnLabel?: string;
   createProfileBtnLabel?: string;
   hideLogout?: boolean;
+  hideNameAndBadge?: boolean;
 }
-export const ProfileButton: FC<Props> = ({ onProfileCreated, loginBtnLabel, createProfileBtnLabel, hideLogout }) => {
+export const ProfileButton: FC<Props> = ({ onProfileCreated, loginBtnLabel, createProfileBtnLabel, hideLogout, hideNameAndBadge }) => {
   const { activeChain } = useContext(ActiveChainContext);
   const { data: sessionData } = useSession();
   const account = useActiveAccount();
@@ -141,9 +142,13 @@ export const ProfileButton: FC<Props> = ({ onProfileCreated, loginBtnLabel, crea
                     className="rounded-full"
                     client={client}
                   />
-                  <span className="text-sm font-normal">{displayUsername}</span>
-                  {sessionData?.user?.fid && (
-                    <CheckBadgeIcon className="w-4 h-4 text-primary" />
+                  {!hideNameAndBadge && (
+                    <>
+                      <span className="text-sm font-normal">{displayUsername}</span>
+                      {sessionData?.user?.fid && (
+                        <CheckBadgeIcon className="w-4 h-4 text-primary" />
+                      )}
+                    </>
                   )}
                 </div>
               </div>

--- a/src/components/utils/BottomNav.tsx
+++ b/src/components/utils/BottomNav.tsx
@@ -37,7 +37,7 @@ export const BottomNav: FC = () => {
         FAQ
       </button>
       <button>
-        <ProfileButton />
+        <ProfileButton hideNameAndBadge />
       </button>
     </div>
   )


### PR DESCRIPTION
## Summary
- Add `hideNameAndBadge` prop to ProfileButton component
- Apply prop to bottom navigation to show only profile avatar
- Keep full profile display (name + badge) in all other locations

## Test plan
- [ ] Verify bottom navigation shows only profile avatar (no name/badge)
- [ ] Verify other ProfileButton instances still show name and verified badge
- [ ] Test with both verified and unverified users

🤖 Generated with [Claude Code](https://claude.ai/code)