### PR TITLE
Filter leaderboard by valid attestations

### DIFF
--- a/docs/LEADERBOARD_MIGRATION.md
+++ b/docs/LEADERBOARD_MIGRATION.md
@@ -93,6 +93,7 @@ Updated `src/pages/api/webhook/dog-events.ts`:
    - Groups all addresses belonging to the same FID together
    - Shows the total count across all addresses
    - Falls back to grouping by address for users without FID
+   - Only counts dogs whose attestations were marked as valid
 
 ## Benefits
 

--- a/src/server/api/dog-events.ts
+++ b/src/server/api/dog-events.ts
@@ -111,6 +111,9 @@ export async function getDogEventLeaderboard(options?: {
     }
   }
 
+  // Only include events with a valid attestation
+  where.attestationValid = true;
+
   // Get all dog events with the filters
   const dogEvents = await db.dogEvent.findMany({
     where,


### PR DESCRIPTION
## Summary
- filter leaderboard dog events so only valid attestations count
- note this rule in the leaderboard migration docs

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686191dba2cc8331839a14a3cb49a0c0