### PR TITLE
Fix mobile zoom on textarea

### DIFF
--- a/src/components/Attestation/Create.tsx
+++ b/src/components/Attestation/Create.tsx
@@ -192,7 +192,7 @@ export const CreateAttestation: FC<Props> = ({ onAttestationCreated }) => {
               </div>
               <div className="collapse-content">
                 <textarea
-                  className="textarea textarea-bordered w-full"
+                  className="textarea textarea-bordered w-full text-base"
                   placeholder="Add a message to your dog"
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}


### PR DESCRIPTION
## Summary
- prevent mobile zoom when focusing description textarea in log-a-dog modal

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails due to dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68616ac738f08331add2b72830d21bd4