### PR TITLE
Fix OG dog count logic

### DIFF
--- a/src/pages/api/og/[logId].tsx
+++ b/src/pages/api/og/[logId].tsx
@@ -7,9 +7,10 @@ import { getSocialProfiles } from 'thirdweb/social';
 import { env } from '~/env';
 import { getHotdogLogsRange } from '~/thirdweb/84532/0x0b04ceb7542cc13e0e483e7b05907c31dbee4d7f';
 import { LOG_A_DOG } from '~/constants/addresses';
+import { getDogEventCountForUser } from '~/server/api/dog-events';
 
 export const config = {
-  runtime: 'edge',
+  runtime: 'nodejs',
 };
 
 // Helper function to convert IPFS URLs to HTTP gateway URLs
@@ -73,17 +74,8 @@ export default async function handler(req: NextRequest) {
       logger: logs[0]!.logger,
     };
 
-    // Get all logs for this user to count their total hotdogs
     try {
-      // Get a large range to find all user's logs (starting from log 0 to current log + some buffer)
-      const allLogs = await getHotdogLogsRange({
-        contract,
-        start: 0n,
-        limit: BigInt(parseInt(logId) + 100), // Get logs up to current + buffer
-      });
-      
-      // Count logs where the eater matches this user
-      userHotdogCount = allLogs.filter(log => log.eater.toLowerCase() === hotdog.eater.toLowerCase()).length;
+      userHotdogCount = await getDogEventCountForUser(hotdog.eater);
     } catch (countError) {
       console.error('Error counting user hotdogs:', countError);
       userHotdogCount = 1; // Fallback to 1 since we know they have at least this log

--- a/src/server/api/dog-events.ts
+++ b/src/server/api/dog-events.ts
@@ -199,3 +199,31 @@ export async function getDogEventLeaderboard(options?: {
 
   return paginatedLeaderboard;
 }
+
+export async function getDogEventCountForUser(address: string) {
+  const user = await db.user.findFirst({
+    where: { address: address.toLowerCase() },
+    select: { fid: true },
+  });
+
+  let addresses: string[] = [address.toLowerCase()];
+
+  if (user?.fid) {
+    const related = await db.user.findMany({
+      where: { fid: user.fid },
+      select: { address: true },
+    });
+
+    addresses = related
+      .map(u => u.address)
+      .filter((a): a is string => !!a)
+      .map(a => a.toLowerCase());
+  }
+
+  return db.dogEvent.count({
+    where: {
+      eater: { in: addresses },
+      attestationValid: true,
+    },
+  });
+}

--- a/src/server/api/routers/hotdog.ts
+++ b/src/server/api/routers/hotdog.ts
@@ -23,6 +23,7 @@ import { canParticipateInAttestation } from "~/thirdweb/84532/0xe6b5534390596422
 import { getUserAttestationsWithChoices } from "~/thirdweb/84532/0xfbc7552a4bc2eaa35ba5e7644b67f3f05b161a56";
 import { getAttestationCounts } from "~/thirdweb/84532/0xc470f55c2877848f1acfcf3b656e01dce03e9ec3";
 import { getDogEventLeaderboard } from "~/server/api/dog-events";
+import { getDogEventCountForUser } from "~/server/api/dog-events";
 
 const redactedImage = "https://ipfs.io/ipfs/QmXZ8SpvGwRgk3bQroyM9x9dQCvd87c23gwVjiZ5FMeXGs/Image%20(1).png";
 
@@ -642,6 +643,18 @@ export const hotdogRouter = createTRPCRouter({
         return result;
       } catch (error) {
         console.error("Error fetching leaderboard from DB:", error);
+        throw error;
+      }
+    }),
+  getUserHotdogCount: publicProcedure
+    .input(z.object({ address: z.string() }))
+    .query(async ({ input }) => {
+      const { address } = input;
+      try {
+        const count = await getDogEventCountForUser(address);
+        return count;
+      } catch (error) {
+        console.error("Error fetching hotdog count for user:", error);
         throw error;
       }
     }),


### PR DESCRIPTION
## Summary
- add helper to count user's dogs with fid grouping and only valid attestations
- expose `getUserHotdogCount` in hotdog router
- use new helper in OG image handler and switch runtime to Node

## Testing
- `npx next lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619cf301d483318273b31842812e16