### PR TITLE
Fix OG user count logic

### DIFF
--- a/src/pages/api/og/[logId].tsx
+++ b/src/pages/api/og/[logId].tsx
@@ -7,6 +7,7 @@ import { getSocialProfiles } from 'thirdweb/social';
 import { env } from '~/env';
 import { getHotdogLogsRange } from '~/thirdweb/84532/0x0b04ceb7542cc13e0e483e7b05907c31dbee4d7f';
 import { LOG_A_DOG } from '~/constants/addresses';
+import { getUserValidDogEventCount } from '~/server/api/dog-events';
 
 export const config = {
   runtime: 'edge',
@@ -73,17 +74,9 @@ export default async function handler(req: NextRequest) {
       logger: logs[0]!.logger,
     };
 
-    // Get all logs for this user to count their total hotdogs
+    // Get all valid logs for this user using the same logic as the leaderboard
     try {
-      // Get a large range to find all user's logs (starting from log 0 to current log + some buffer)
-      const allLogs = await getHotdogLogsRange({
-        contract,
-        start: 0n,
-        limit: BigInt(parseInt(logId) + 100), // Get logs up to current + buffer
-      });
-      
-      // Count logs where the eater matches this user
-      userHotdogCount = allLogs.filter(log => log.eater.toLowerCase() === hotdog.eater.toLowerCase()).length;
+      userHotdogCount = await getUserValidDogEventCount(hotdog.eater);
     } catch (countError) {
       console.error('Error counting user hotdogs:', countError);
       userHotdogCount = 1; // Fallback to 1 since we know they have at least this log


### PR DESCRIPTION
## Summary
- use DB-based counting logic for OG images
- expose helper `getUserValidDogEventCount`

## Testing
- `bun run build` *(fails: `next build` not found / dependencies not installed)*
- `npm run lint` *(fails: invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68619cf301d483318273b31842812e16