### PR TITLE
Fix leaderboard loading flash

### DIFF
--- a/src/components/LeaderboardBanner.tsx
+++ b/src/components/LeaderboardBanner.tsx
@@ -46,7 +46,7 @@ export const LeaderboardBanner: FC<Props> = ({
   });
 
   if (!leaderboard || !profiles) return (
-    <div className="bg-base-200 rounded-lg animate-pulse w-full h-20" />
+    <div className="bg-base-200 rounded-lg w-full h-20" />
   );
 
   const users = leaderboard.users ?? [];


### PR DESCRIPTION
## Summary
- remove `animate-pulse` from `LeaderboardBanner` placeholder

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a19cbe148331bfed84dffa0f4b13