### PR TITLE
Add Profile label in bottom navigation

### DIFF
--- a/src/components/Profile/Button.tsx
+++ b/src/components/Profile/Button.tsx
@@ -27,8 +27,9 @@ type Props = {
   createProfileBtnLabel?: string;
   hideLogout?: boolean;
   hideNameAndBadge?: boolean;
+  label?: string;
 }
-export const ProfileButton: FC<Props> = ({ onProfileCreated, loginBtnLabel, createProfileBtnLabel, hideLogout, hideNameAndBadge }) => {
+export const ProfileButton: FC<Props> = ({ onProfileCreated, loginBtnLabel, createProfileBtnLabel, hideLogout, hideNameAndBadge, label }) => {
   const { activeChain } = useContext(ActiveChainContext);
   const { data: sessionData } = useSession();
   const account = useActiveAccount();
@@ -138,17 +139,19 @@ export const ProfileButton: FC<Props> = ({ onProfileCreated, loginBtnLabel, crea
                     src={img()}
                     alt="Profile Pic"
                     width={"24px"}
-                    height={"24px"} 
+                    height={"24px"}
                     className="rounded-full"
                     client={client}
                   />
-                  {!hideNameAndBadge && (
+                  {!hideNameAndBadge ? (
                     <>
                       <span className="text-sm font-normal">{displayUsername}</span>
                       {sessionData?.user?.fid && (
                         <CheckBadgeIcon className="w-4 h-4 text-primary" />
                       )}
                     </>
+                  ) : (
+                    label && <span className="text-sm font-normal">{label}</span>
                   )}
                 </div>
               </div>

--- a/src/components/utils/BottomNav.tsx
+++ b/src/components/utils/BottomNav.tsx
@@ -36,9 +36,9 @@ export const BottomNav: FC = () => {
         <QuestionMarkCircleIcon className="h-6 w-6" />
         FAQ
       </button>
-      <button>
-        <ProfileButton hideNameAndBadge />
-      </button>
-    </div>
-  )
-}
+        <button>
+          <ProfileButton hideNameAndBadge label="Profile" />
+        </button>
+      </div>
+    )
+  }


### PR DESCRIPTION
## Summary
- accept optional `label` prop in `ProfileButton`
- show label when `hideNameAndBadge` is true
- display label in bottom navigation

## Testing
- `npm run lint` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_6861ca5dd4d48331bb884c33d0983a78