### PR TITLE
Ensure page bottom padding

### DIFF
--- a/src/components/utils/Layout.tsx
+++ b/src/components/utils/Layout.tsx
@@ -33,7 +33,7 @@ export const Layout: FC<LayoutProps> = ({ children }) => {
       <div className={`fixed bg-gradient-to-br ${fromYellow} ${viaPink} ${toPink} rounded-full blur-3xl -bottom-0 -left-[55%] w-1/2 h-full -z-10 ${darkModeOpacity}`}></div>
       <div className={`fixed bg-gradient-to-tl ${fromYellow} ${viaPink} ${toYellow} rounded-full blur-3xl -bottom-0 -left-[25%] w-1/2 h-full -z-10 ${darkModeOpacity}`}></div>
       <div className={`fixed bg-gradient-to-bl ${fromPink} ${toPink} rounded-full -top-[-85%] blur-3xl -left-[35%] w-full h-full -z-10 ${darkModeOpacity}`}></div>
-      <div className="overflow-x-hidden max-w-7xl mx-auto min-h-screen">
+      <div className="overflow-x-hidden max-w-7xl mx-auto min-h-screen pb-24">
         <div className="w-full justify-between items-center flex mr-4">
           <div className="flex items-center gap-2">
             {router.pathname !== '/' && (

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -13,7 +13,7 @@ const FAQPage: NextPage = () => {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <main className="flex min-h-screen flex-col items-center justify-center">
-        <div className="container flex flex-col items-center justify-center gap-6 px-4 pt-16">
+        <div className="container flex flex-col items-center justify-center gap-6 px-4 pt-16 pb-8">
           <h1 className="text-5xl font-extrabold tracking-tight sm:text-[5rem] flex items-center">
             <div>🌭 FAQ & <span className="text-secondary">Instructions</span></div>
           </h1>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -43,7 +43,7 @@ export default function Home() {
       </Head>
       <main className="flex min-h-screen flex-col items-center justify-center">
         <LeaderboardBanner refetchTimestamp={refetchTimestamp} />
-        <div className="container flex flex-col items-center justify-center gap-6 px-4 pt-8 pb-20">
+        <div className="container flex flex-col items-center justify-center gap-6 px-4 pt-8 pb-8">
           <h1 className="text-5xl font-extrabold tracking-tight sm:text-[5rem] flex items-center">
             <div>🌭 Log <span className="text-secondary">a Dog</span> </div>
           </h1>


### PR DESCRIPTION
## Summary
- add consistent bottom padding in Layout so content isn't hidden by bottom nav
- adjust home and faq pages padding

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861d1f40dd88331863da5e5c9861e4b