### PR TITLE
Fix profile creation flow

### DIFF
--- a/src/components/Profile/Form.tsx
+++ b/src/components/Profile/Form.tsx
@@ -4,7 +4,6 @@ import ActiveChainContext from "~/contexts/ActiveChain";
 import { toast } from "react-toastify";
 import dynamic from 'next/dynamic';
 import { api } from "~/utils/api";
-import { useRouter } from "next/router";
 import { useSession } from "next-auth/react";
 
 const Upload = dynamic(() => import('~/components/utils/Upload'), { ssr: false });
@@ -32,7 +31,6 @@ export const ProfileForm: FC<Props> = ({ onProfileSaved, existingUsername, exist
   const [saveProfileBtnLabel, setSaveProfileBtnLabel] = useState<string>("Save Profile");
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
-  const router = useRouter();
   
   const createProfile = api.profile.create.useMutation({
     onSuccess: () => {
@@ -43,8 +41,6 @@ export const ProfileForm: FC<Props> = ({ onProfileSaved, existingUsername, exist
       toast.success("Profile saved successfully!");
       // close the modal
       (document.getElementById('create_profile_modal') as HTMLDialogElement)?.close();
-      // navigate to the profile page of the new username
-      void router.push(`/profile/${username}`);
     },
     onError: (error) => {
       setError(error.message);


### PR DESCRIPTION
## Summary
- stop redirecting user after profile creation so the nav immediately updates

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_6861fef78ef08331a67bccd032bc86a7