### PR TITLE
Fix optimistic dog duplication

### DIFF
--- a/src/components/Attestation/Create.tsx
+++ b/src/components/Attestation/Create.tsx
@@ -59,6 +59,13 @@ export const CreateAttestation: FC<Props> = ({ onAttestationCreated }) => {
     }
   }, [isMiniApp, dogEvent, isTransactionIdResolved]);
 
+  // Remove the optimistic dog once the real data is available
+  useEffect(() => {
+    if (dogEvent && transactionId) {
+      removePendingDog(transactionId);
+    }
+  }, [dogEvent, transactionId, removePendingDog]);
+
   const handleOnResolved = (success: boolean) => {
     if (success && account && transactionId) {
       // Keep the optimistic data - don't remove it here


### PR DESCRIPTION
## Summary
- remove optimistic dog record when actual dog data is fetched

## Testing
- `npx prettier -w src/components/Attestation/Create.tsx` *(fails: Cannot find package)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68627a774f9c8331bb2a1132abad3b05