### PR TITLE
Convert hero image to text

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -25,6 +25,10 @@ class MyDocument extends Document {
           <meta property="twitter:description" content="Track how many hotdogs you eat and compete against your friends!" />
           <meta property="twitter:image" content="https://logadog.xyz/images/og-image.png" />
 
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+          <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@400;600;700;800;900&display=swap" rel="stylesheet" />
+
           {/* Additional tags here */}
         </Head>
         <body>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import Head from "next/head";
 import Link from "next/link";
 // import Link from "next/link";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { CreateAttestation } from "~/components/Attestation/Create";
 import { ListAttestations } from "~/components/Attestation/List";
 import { LeaderboardBanner } from "~/components/LeaderboardBanner";
@@ -33,6 +33,13 @@ export const getStaticProps = async () => {
 
 export default function Home() {
   const [refetchTimestamp, setRefetchTimestamp] = useState<number>(0);
+  const [userPrefersDarkMode, setUserPrefersDarkMode] = useState<boolean>(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    setUserPrefersDarkMode(window.matchMedia('(prefers-color-scheme: dark)').matches);
+  }, []);
 
   return (
     <>
@@ -45,14 +52,12 @@ export default function Home() {
       <main className="flex min-h-screen flex-col items-center justify-center">
         <LeaderboardBanner refetchTimestamp={refetchTimestamp} />
         <div className="container flex flex-col items-center justify-center gap-4 px-4 pt-8 pb-8">
-          <h1 className="text-5xl font-extrabold tracking-tight sm:text-[5rem] flex items-center">
-            <Image
-              src="/images/banner.png"
-              alt="Log a Dog"
-              width={500}
-              height={500}
-              priority
-            />
+          <h1
+            className={`font-league flex flex-col items-center text-5xl font-extrabold tracking-tight sm:text-[5rem] ${mounted ? (userPrefersDarkMode ? 'text-white' : 'text-black') : ''}`}
+            style={{ filter: 'drop-shadow(0 -9px 19px rgba(236, 72, 153, 0.75)) drop-shadow(0 -6px 15px rgba(254, 240, 138, 0.5))' }}
+          >
+            <span>Log a Dog</span>
+            <span className="sm:text-4xl text-2xl">Season 2</span>
           </h1>
           <div className="flex items-center gap-2 -mt-8">
             <p className="sm:text-lg text-sm text-center max-w-xs">{APP_DESCRIPTION}</p>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,6 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
+@import url('https://fonts.googleapis.com/css2?family=League+Spartan:wght@400;600;700;800;900&display=swap');
+
 @font-face {
   font-family: 'Segment';
   src: url('/fonts/Segment/Segment-Medium.otf') format('opentype');
@@ -36,5 +38,11 @@
 
 .thirdweb_btn_btn-circle_btn-ghost_btn-xs_w-fit {
   @apply btn btn-circle btn-ghost btn-xs w-fit !important;
+}
+
+@layer utilities {
+  .font-league {
+    font-family: 'League Spartan', 'Segment', system-ui, sans-serif;
+  }
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,6 +3,11 @@ import { type Config } from "tailwindcss";
 export default {
   content: ["./src/**/*.tsx"],
   theme: {
+    extend: {
+      fontFamily: {
+        league: ['"League Spartan"', 'sans-serif'],
+      },
+    },
   },
   plugins: [require("daisyui")],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- replace banner PNG with text using League Spartan font
- add League Spartan font from Google Fonts
- configure Tailwind to use the new font
- ensure font is loaded in the document

## Testing
- `npx next lint` *(fails: need next package)*

------
https://chatgpt.com/codex/tasks/task_e_6867278e748083319e370bb7b3982708