### PR TITLE
Add profanity filter for usernames

### DIFF
--- a/src/components/Profile/Form.tsx
+++ b/src/components/Profile/Form.tsx
@@ -6,6 +6,7 @@ import dynamic from 'next/dynamic';
 import { api } from "~/utils/api";
 import { useRouter } from "next/router";
 import { useSession } from "next-auth/react";
+import { containsProfanity } from "~/utils/profanity";
 
 const Upload = dynamic(() => import('~/components/utils/Upload'), { ssr: false });
 
@@ -54,7 +55,11 @@ export const ProfileForm: FC<Props> = ({ onProfileSaved, existingUsername, exist
   });
 
   const isValidUsername = useMemo(() => {
-    return username.length >= 3 && username.length <= 20;
+    return (
+      username.length >= 3 &&
+      username.length <= 20 &&
+      !containsProfanity(username)
+    );
   }, [username]);
 
   const withGateway = (url: string) => {
@@ -111,7 +116,7 @@ export const ProfileForm: FC<Props> = ({ onProfileSaved, existingUsername, exist
       />
       {!isValidUsername && (
         <span className="text-xs opacity-50 text-center px-8 sm:px-16">
-          Username must be 3-20 characters and only contain lowercase letters, numbers, and hyphens
+          Username must be 3-20 characters, contain only lowercase letters, numbers, and hyphens, and not include profanity
         </span>
       )}
       <button

--- a/src/server/api/routers/profile.ts
+++ b/src/server/api/routers/profile.ts
@@ -7,6 +7,7 @@ import {
   publicProcedure,
 } from "~/server/api/trpc";
 import { db } from "~/server/db";
+import { containsProfanity } from "~/utils/profanity";
 
 export const profileRouter = createTRPCRouter({
   getByAddress: publicProcedure
@@ -141,6 +142,10 @@ export const profileRouter = createTRPCRouter({
     }))
     .mutation(async ({ input }) => {
       const { chainId, address, username, imgUrl } = input;
+
+      if (containsProfanity(username)) {
+        throw new Error("Username contains profanity or slurs");
+      }
       
       // Save profile data to database
       // First try to find existing user by address

--- a/src/utils/profanity.ts
+++ b/src/utils/profanity.ts
@@ -1,0 +1,18 @@
+const bannedWords = [
+  'fuck',
+  'shit',
+  'bitch',
+  'cunt',
+  'asshole',
+  'dick',
+  'bastard',
+  'slut',
+  'whore',
+  'fag',
+  'nigger'
+];
+
+export function containsProfanity(text: string): boolean {
+  const lower = text.toLowerCase();
+  return bannedWords.some(word => lower.includes(word));
+}


### PR DESCRIPTION
## Summary
- add `containsProfanity` helper
- validate usernames client and server side

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e957e41c8331aa9ae48a85dd9cc1