### PR TITLE
Fix pagination

### DIFF
--- a/src/server/api/routers/hotdog.ts
+++ b/src/server/api/routers/hotdog.ts
@@ -430,7 +430,7 @@ export const hotdogRouter = createTRPCRouter({
         userAttested: processedResponse.userHasAttested,
         userAttestations: processedResponse.userAttestations,
         totalPages: Number(totalPages),
-        hasNextPage: start + limit < Number(totalPages),
+        hasNextPage: start + limit < totalEvents,
       };
 
       // TEMPORARILY DISABLE CACHING during development


### PR DESCRIPTION
## Summary
- fix `hasNextPage` calculation to compare the fetched item count instead of total pages

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install --legacy-peer-deps` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68688923851883319fe9e4cc08d56684