### PR TITLE
Fix homepage refresh loop

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -82,7 +82,7 @@ export default function Home() {
               }, 10000);
             }}
           />
-          <ListAttestations refetchTimestamp={refetchTimestamp} key={refetchTimestamp} limit={10} />
+          <ListAttestations refetchTimestamp={refetchTimestamp} limit={10} />
         </div>
       </main>
     </>


### PR DESCRIPTION
## Summary
- avoid remounting the hotdog list when refreshing

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68696b346eac83318f5af3317959bc40