### PR TITLE
Fix homepage refresh loop

### DIFF
--- a/src/components/Attestation/Create.tsx
+++ b/src/components/Attestation/Create.tsx
@@ -107,9 +107,11 @@ export const CreateAttestation: FC<Props> = ({ onAttestationCreated }) => {
       // Keep the optimistic data - don't remove it here
       // Let it be naturally filtered out when real data appears
 
-      // Just do a gentle invalidation - no forced refetch
-      console.log('🔄 Transaction resolved, gentle cache invalidation');
+      // Invalidate cached queries so lists update when the new dog appears
+      console.log('🔄 Transaction resolved, invalidating caches');
       void utils.hotdog.getAll.invalidate();
+      void utils.hotdog.getAllForUser.invalidate();
+      void utils.hotdog.getLeaderboard.invalidate();
 
     } else if (!success && transactionId) {
       // If transaction failed, remove the optimistic update

--- a/src/components/Attestation/List.tsx
+++ b/src/components/Attestation/List.tsx
@@ -84,12 +84,11 @@ type Props = {
   attestors?: string[];
   startDate?: Date;
   endDate?: Date;
-  refetchTimestamp?: number;
   limit: number;
   address?: string;
 };
 
-export const ListAttestations: FC<Props> = ({ limit, refetchTimestamp }) => {
+export const ListAttestations: FC<Props> = ({ limit }) => {
   const limitOrDefault = limit ?? 4;
   const { activeChain } = useContext(ActiveChainContext);
   const [start, setStart] = useState<number>(0);
@@ -111,12 +110,6 @@ export const ListAttestations: FC<Props> = ({ limit, refetchTimestamp }) => {
   const { data: dogData, isLoading: isLoadingHotdogs, refetch: refetchDogData } = api.hotdog.getAll.useQuery(queryParams, {
     enabled: !!activeChain.id && isClient, // Only run query on client side
   });
-
-  useEffect(() => {
-    if (refetchTimestamp) {
-      void refetchDogData();
-    }
-  }, [refetchTimestamp, refetchDogData]);
 
   // Get pending dogs for current chain
   const pendingDogs = getPendingDogsForChain(activeChain.id.toString());

--- a/src/components/Attestation/List.tsx
+++ b/src/components/Attestation/List.tsx
@@ -89,7 +89,7 @@ type Props = {
   address?: string;
 };
 
-export const ListAttestations: FC<Props> = ({ limit }) => {
+export const ListAttestations: FC<Props> = ({ limit, refetchTimestamp }) => {
   const limitOrDefault = limit ?? 4;
   const { activeChain } = useContext(ActiveChainContext);
   const [start, setStart] = useState<number>(0);
@@ -111,6 +111,12 @@ export const ListAttestations: FC<Props> = ({ limit }) => {
   const { data: dogData, isLoading: isLoadingHotdogs, refetch: refetchDogData } = api.hotdog.getAll.useQuery(queryParams, {
     enabled: !!activeChain.id && isClient, // Only run query on client side
   });
+
+  useEffect(() => {
+    if (refetchTimestamp) {
+      void refetchDogData();
+    }
+  }, [refetchTimestamp, refetchDogData]);
 
   // Get pending dogs for current chain
   const pendingDogs = getPendingDogsForChain(activeChain.id.toString());

--- a/src/components/Attestation/UserList.tsx
+++ b/src/components/Attestation/UserList.tsx
@@ -15,7 +15,6 @@ type Props = {
   attestors?: string[];
   startDate?: Date;
   endDate?: Date;
-  refetchTimestamp?: number;
   limit: number;
   user: string;
 };

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -10,10 +10,9 @@ type Props = {
   startDate?: Date;
   endDate?: Date;
   limit?: number;
-  refetchTimestamp: number;
 }
 
-export const Leaderboard: FC<Props> = ({ limit, startDate, endDate, refetchTimestamp }) => {
+export const Leaderboard: FC<Props> = ({ limit, startDate, endDate }) => {
   const limitOrDefault = limit ?? 10;
   const { activeChain } = useContext(ActiveChainContext);
   const [page, setPage] = useState(0);
@@ -30,11 +29,7 @@ export const Leaderboard: FC<Props> = ({ limit, startDate, endDate, refetchTimes
     refetchOnMount: false,
   });
 
-  useEffect(() => {
-    if (refetchTimestamp) {
-      void refetch();
-    }
-  }, [refetch, refetchTimestamp]);
+  // React Query will automatically refetch when its cache is invalidated
 
   const { data: profiles } = api.profile.getManyByAddress.useQuery({
     chainId: activeChain.id,

--- a/src/components/LeaderboardBanner.tsx
+++ b/src/components/LeaderboardBanner.tsx
@@ -9,19 +9,17 @@ import styles from "./LeaderboardBanner.module.css";
 type Props = {
   startDate?: Date;
   endDate?: Date;
-  refetchTimestamp: number;
   scrollSpeed?: number; // pixels per second
 }
 
-export const LeaderboardBanner: FC<Props> = ({ 
-  startDate, 
-  endDate, 
-  refetchTimestamp, 
-  scrollSpeed = 50 
+export const LeaderboardBanner: FC<Props> = ({
+  startDate,
+  endDate,
+  scrollSpeed = 50
 }) => {
   const { activeChain } = useContext(ActiveChainContext);
 
-  const { data: leaderboard, refetch } = api.hotdog.getLeaderboard.useQuery({
+  const { data: leaderboard } = api.hotdog.getLeaderboard.useQuery({
     chainId: activeChain.id,
     ...startDate && { startDate: Math.floor(startDate.getTime() / 1000) },
     ...endDate && { endDate: Math.floor(endDate.getTime() / 1000) },
@@ -30,11 +28,7 @@ export const LeaderboardBanner: FC<Props> = ({
     refetchOnMount: false,
   });
 
-  useEffect(() => {
-    if (refetchTimestamp) {
-      void refetch();
-    }
-  }, [refetch, refetchTimestamp]);
+  // React Query automatically updates when caches are invalidated
 
   const { data: profiles } = api.profile.getManyByAddress.useQuery({
     chainId: activeChain.id,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from "react";
 import { CreateAttestation } from "~/components/Attestation/Create";
 import { ListAttestations } from "~/components/Attestation/List";
 import { LeaderboardBanner } from "~/components/LeaderboardBanner";
+import { api } from "~/utils/api";
 import { APP_DESCRIPTION } from "~/constants";
 import Image from "next/image";
 
@@ -32,7 +33,7 @@ export const getStaticProps = async () => {
 };
 
 export default function Home() {
-  const [refetchTimestamp, setRefetchTimestamp] = useState<number>(0);
+  const utils = api.useUtils();
   const [userPrefersDarkMode, setUserPrefersDarkMode] = useState<boolean>(false);
   const [mounted, setMounted] = useState(false);
 
@@ -57,7 +58,7 @@ export default function Home() {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <main className="flex min-h-screen flex-col items-center justify-center">
-        <LeaderboardBanner refetchTimestamp={refetchTimestamp} />
+        <LeaderboardBanner />
         <div className="container flex flex-col items-center justify-center gap-4 px-4 pt-8 pb-8">
           <h1 className="text-5xl font-extrabold tracking-tight sm:text-[5rem] flex items-center">
             <Image
@@ -78,11 +79,12 @@ export default function Home() {
             onAttestationCreated={() => {
               // give the blockchain 10 seconds to confirm
               setTimeout(() => {
-                setRefetchTimestamp(new Date().getTime())
+                void utils.hotdog.getAll.invalidate();
+                void utils.hotdog.getLeaderboard.invalidate();
               }, 10000);
             }}
           />
-          <ListAttestations refetchTimestamp={refetchTimestamp} limit={10} />
+          <ListAttestations limit={10} />
         </div>
       </main>
     </>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -82,7 +82,7 @@ export default function Home() {
               }, 10000);
             }}
           />
-          <ListAttestations refetchTimestamp={refetchTimestamp} key={refetchTimestamp} limit={10} />
+          <ListAttestations refetchTimestamp={refetchTimestamp} limit={10} />
         </div>
       </main>
     </>

--- a/src/pages/profile/[username].tsx
+++ b/src/pages/profile/[username].tsx
@@ -36,7 +36,7 @@ export const Profile: NextPage<{ username: string }> = ({ username }) => {
     refetchOnWindowFocus: false,
     refetchOnMount: false,
   });
-  const [refetchTimestamp, setRefetchTimestamp] = useState<number>(0);
+  const utils = api.useUtils();
   const [showProfileForm, setShowProfileForm] = useState<boolean>(false);
 
   // Check if this is the user's own profile
@@ -94,10 +94,13 @@ export const Profile: NextPage<{ username: string }> = ({ username }) => {
             />
           )}
           {isOwnProfile && (
-            <CreateAttestation onAttestationCreated={() => setRefetchTimestamp(new Date().getTime())} />
+            <CreateAttestation onAttestationCreated={() => {
+              setTimeout(() => {
+                void utils.hotdog.getAllForUser.invalidate();
+              }, 10000);
+            }} />
           )}
           <UserListAttestations
-            refetchTimestamp={refetchTimestamp}
             limit={4}
             user={data.address}
           />

--- a/src/pages/profile/address/[address].tsx
+++ b/src/pages/profile/address/[address].tsx
@@ -37,7 +37,7 @@ export const Profile: NextPage<{ address: string }> = ({ address }) => {
     refetchOnMount: false,
   });
   console.log({ data });
-  const [refetchTimestamp, setRefetchTimestamp] = useState<number>(0);
+  const utils = api.useUtils();
   const [showProfileForm, setShowProfileForm] = useState<boolean>(false);
 
   // Check if this is the user's own profile
@@ -95,10 +95,13 @@ export const Profile: NextPage<{ address: string }> = ({ address }) => {
             />
           )}
           {isOwnProfile && (
-            <CreateAttestation onAttestationCreated={() => setRefetchTimestamp(new Date().getTime())} />
+            <CreateAttestation onAttestationCreated={() => {
+              setTimeout(() => {
+                void utils.hotdog.getAllForUser.invalidate();
+              }, 10000);
+            }} />
           )}
           <UserListAttestations
-            refetchTimestamp={refetchTimestamp}
             limit={4}
             user={data.address}
           />

--- a/src/pages/profile/id/[id].tsx
+++ b/src/pages/profile/id/[id].tsx
@@ -37,7 +37,7 @@ export const Profile: NextPage<{ id: string }> = ({ id }) => {
     refetchOnMount: false,
   });
   console.log({ data });
-  const [refetchTimestamp, setRefetchTimestamp] = useState<number>(0);
+  const utils = api.useUtils();
   const [showProfileForm, setShowProfileForm] = useState<boolean>(false);
 
   // Check if this is the user's own profile
@@ -95,10 +95,13 @@ export const Profile: NextPage<{ id: string }> = ({ id }) => {
             />
           )}
           {isOwnProfile && (
-            <CreateAttestation onAttestationCreated={() => setRefetchTimestamp(new Date().getTime())} />
+            <CreateAttestation onAttestationCreated={() => {
+              setTimeout(() => {
+                void utils.hotdog.getAllForUser.invalidate();
+              }, 10000);
+            }} />
           )}
           <UserListAttestations
-            refetchTimestamp={refetchTimestamp}
             limit={4}
             user={data.address}
           />


### PR DESCRIPTION
## Summary
- trigger hotdog list query on timestamp change instead of remounting

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68696b346eac83318f5af3317959bc40