### PR TITLE
Add link to hotdog images

### DIFF
--- a/src/components/Attestation/List.tsx
+++ b/src/components/Attestation/List.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import { useContext, useEffect, type FC, useState, useMemo } from "react";
+import Link from "next/link";
 import ActiveChainContext from "~/contexts/ActiveChain";
 import { api } from "~/utils/api";
 import HotdogImage from "~/components/utils/HotdogImage";
@@ -284,13 +285,16 @@ export const ListAttestations: FC<Props> = ({ limit }) => {
                   <div className="flex items-center gap-0.5"><FireIcon className="w-4 h-4" /> 24H VOL ${formatAbbreviatedFiat(Number(hotdog.zoraCoin.volume24h))}</div>
                 </div>
               )}
-              <HotdogImage
-                src={hotdog.imageUri}
-                zoraCoin={hotdog.zoraCoin}
-                className="rounded-lg"
-                width="400"
-                height="400"
-              />
+              <Link href={`/dog/${hotdog.logId}`}
+                className="w-fit">
+                <HotdogImage
+                  src={hotdog.imageUri}
+                  zoraCoin={hotdog.zoraCoin}
+                  className="rounded-lg"
+                  width="400"
+                  height="400"
+                />
+              </Link>
               <div className="opacity-50 flex flex-row w-full items-center justify-between">
                 <div className="text-xs flex items-center gap-1">
                   {('attestationPeriod' in hotdog && hotdog.attestationPeriod) && (


### PR DESCRIPTION
## Summary
- ensure each hotdog image on the homepage links to its detail page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869bb81511883319af66cb1ce34ba7b