### PR TITLE
Handle Maker wallet logs

### DIFF
--- a/src/components/Attestation/List.tsx
+++ b/src/components/Attestation/List.tsx
@@ -18,7 +18,7 @@ import { formatAbbreviatedFiat } from "~/helpers/formatFiat";
 import AttestationStatusBadge from "~/components/Attestation/AttestationStatusBadge";
 import { usePendingTransactionsStore, type PendingDogEvent } from "~/stores/pendingTransactions";
 
-import { ATTESTATION_WINDOW_SECONDS } from "~/constants";
+import { ATTESTATION_WINDOW_SECONDS, MAKER_WALLET } from "~/constants";
 
 // Types from hotdog router
 type AttestationPeriod = {
@@ -221,7 +221,7 @@ export const ListAttestations: FC<Props> = ({ limit }) => {
     );
     const loggerIsNotMakerWallet = !isAddressEqual(
       hotdog.logger as `0x${string}`,
-      "0x9622D04739a54313e3B057051Ea42DafBE4fbd4f",
+      MAKER_WALLET,
     );
     return loggerIsNotEater && loggerIsNotBackendWallet && loggerIsNotMakerWallet;
   };

--- a/src/constants/addresses.ts
+++ b/src/constants/addresses.ts
@@ -61,3 +61,5 @@ export const PROTOCOL_REWARDS: ContractAddress = {
   [baseSepolia.id]: "0x7777777F279eba3d3Ad8F4E708545291A6fDBA8B",
 }
 
+export const MAKER_WALLET = "0x9622D04739a54313e3B057051Ea42DafBE4fbd4f" as `0x${string}`
+

--- a/src/pages/dog/DogPageComponent.tsx
+++ b/src/pages/dog/DogPageComponent.tsx
@@ -21,7 +21,7 @@ import { ZERO_ADDRESS } from "thirdweb";
 import { env } from "~/env";
 import { isAddressEqual } from "viem";
 import { formatAbbreviatedFiat } from "~/helpers/formatFiat";
-import { ATTESTATION_WINDOW_SECONDS } from "~/constants";
+import { ATTESTATION_WINDOW_SECONDS, MAKER_WALLET } from "~/constants";
 import AttestationStatusBadge from "~/components/Attestation/AttestationStatusBadge";
 
 const DogPage: NextPage<{ logId: string }> = ({ logId }) => {
@@ -57,7 +57,7 @@ const DogPage: NextPage<{ logId: string }> = ({ logId }) => {
     );
     const loggerIsNotMakerWallet = !isAddressEqual(
       hotdog.logger,
-      "0x9622D04739a54313e3B057051Ea42DafBE4fbd4f",
+      MAKER_WALLET,
     );
     return loggerIsNotEater && loggerIsNotBackendWallet && loggerIsNotMakerWallet;
   };

--- a/src/server/api/routers/hotdog.ts
+++ b/src/server/api/routers/hotdog.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable prefer-const */
 import { z } from "zod";
-import { AI_AFFIRMATION, ATTESTATION_MANAGER, LOG_A_DOG, MODERATION, STAKING } from "~/constants/addresses";
+import { AI_AFFIRMATION, ATTESTATION_MANAGER, LOG_A_DOG, MODERATION, STAKING, MAKER_WALLET } from "~/constants/addresses";
 import { encode, getContract, getGasPrice, prepareTransaction } from "thirdweb";
 import { SUPPORTED_CHAINS } from "~/constants/chains";
 
@@ -843,12 +843,12 @@ export const hotdogRouter = createTRPCRouter({
       
       try {
         // const { transactionId } = await serverWallet.enqueueTransaction({ transaction: preparedTransaction });
-        const headers = {
-          // Authorization: `Bearer ${env.THIRDWEB_ENGINE_API_KEY}`,
-          Authorization: `Bearer ${env.THIRDWEB_SECRET_KEY}`,
-          'Content-Type': 'application/json',
-          'X-Backend-Wallet-Address': '0x9622D04739a54313e3B057051Ea42DafBE4fbd4f',
-        }
+          const headers = {
+            // Authorization: `Bearer ${env.THIRDWEB_ENGINE_API_KEY}`,
+            Authorization: `Bearer ${env.THIRDWEB_SECRET_KEY}`,
+            'Content-Type': 'application/json',
+            'X-Backend-Wallet-Address': MAKER_WALLET,
+          }
         const body = {
           functionName: 'logHotdogOnBehalf',
           args: [


### PR DESCRIPTION
## Summary
- skip showing `via` label when dog logs are from Maker's wallet

## Testing
- `bun install` *(fails: `prisma` not found)*
- `bun run build` *(fails to download Prisma binaries: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6869d36af84083318d4df38a4628eb84