### PR TITLE
Use swap token sdk

### DIFF
--- a/src/components/utils/Buy.tsx
+++ b/src/components/utils/Buy.tsx
@@ -2,14 +2,11 @@ import { useContext, useEffect, useState, type FC } from "react";
 import { darkTheme, lightTheme, BuyWidget } from "thirdweb/react";
 import { client } from "~/providers/Thirdweb";
 import { Portal } from "./Portal";
-import useActiveChain from "~/hooks/useActiveChain";
-import { HOTDOG_TOKEN, MINIMUM_STAKE } from "~/constants";
+import { DEFAULT_CHAIN, HOTDOG_TOKEN, MINIMUM_STAKE } from "~/constants";
 import { toTokens } from "thirdweb";
 import { FarcasterContext } from "~/providers/Farcaster";
-import sdk from "@farcaster/frame-sdk";
 
 export const Buy: FC = () => {
-  const { activeChain } = useActiveChain();
   const farcaster = useContext(FarcasterContext);
   const isMiniApp = farcaster?.isMiniApp ?? false;
   const [userPrefersDarkMode, setUserPrefersDarkMode] = useState<boolean>(false);
@@ -19,7 +16,7 @@ export const Buy: FC = () => {
 
   const handleMiniAppBuy = async () => {
     if (!farcaster?.context) return;
-    return farcaster.swapToken(HOTDOG_TOKEN[activeChain.id]! as `0x${string}`);
+    return farcaster.swapToken(HOTDOG_TOKEN[DEFAULT_CHAIN.id]! as `0x${string}`, toTokens(MINIMUM_STAKE, 18));
   }
 
   if (isMiniApp) {
@@ -41,8 +38,8 @@ export const Buy: FC = () => {
           <div className="modal-box backdrop-blur-sm bg-opacity-50 w-full p-0 m-0 flex items-center justify-center">
             <BuyWidget
               client={client}
-              chain={activeChain}
-              tokenAddress={HOTDOG_TOKEN[activeChain.id]! as `0x${string}`}
+              chain={DEFAULT_CHAIN}
+              tokenAddress={HOTDOG_TOKEN[DEFAULT_CHAIN.id]! as `0x${string}`}
               amount={toTokens(MINIMUM_STAKE, 18)}
               title="Buy $HOTDOG"
               theme={userPrefersDarkMode

--- a/src/providers/Farcaster.tsx
+++ b/src/providers/Farcaster.tsx
@@ -7,6 +7,7 @@ import useActiveChain from '~/hooks/useActiveChain';
 import { client } from '~/providers/Thirdweb';
 import { sdk, type Context } from "@farcaster/frame-sdk";
 import { useConnect } from "thirdweb/react";
+import { DEFAULT_CHAIN } from '~/constants';
 
 // Use environment variable or fallback to localhost for development
 const url = env.NEXT_PUBLIC_APP_DOMAIN || 'http://localhost:3000';
@@ -21,7 +22,7 @@ type FarcasterContextType = {
   context: Context.FrameContext | undefined;
   isMiniApp: boolean;
   viewProfile: (fid: number) => Promise<void>;
-  swapToken: (token: string) => Promise<void>;
+  swapToken: (token: string, sellAmount?: string) => Promise<void>;
 };
 
 export const FarcasterContext = createContext<FarcasterContextType | null>(null);
@@ -60,9 +61,10 @@ export const FarcasterProvider = ({ children } : {
     }
   }, []);
 
-  const swapToken = useCallback(async (token: string) => {
+  const swapToken = useCallback(async (token: string, sellAmount?: string) => {
     try {
-      await sdk.actions.swapToken({ buyToken: token });
+      const CAIP19 = `eip155:${DEFAULT_CHAIN.id}/erc20:${token}`;
+      await sdk.actions.swapToken({ buyToken: CAIP19, sellAmount });
     } catch (err) {
       console.error("Failed to swap token", err);
     }


### PR DESCRIPTION
## Summary
Adds native token swapping support when the app is running as a Farcaster miniapp, providing a more streamlined user experience for buying $HOTDOG tokens within the Farcaster ecosystem.

## Changes
- **Enhanced Buy component**: Added conditional rendering for Farcaster miniapp context
- **Added swapToken function**: Implemented token swapping using Farcaster Frame SDK
- **Updated BuyWidget**: Changed hardcoded amount from "100" to use `MINIMUM_STAKE` constant for consistency
- **Improved UX**: Users in Farcaster miniapp now get a direct "Buy $HOTDOG" button instead of the modal

## Technical Details
- Added `swapToken` method to `FarcasterProvider` context
- Uses `sdk.actions.swapToken` from `@farcaster/frame-sdk`
- Maintains backward compatibility with existing web interface
- Properly handles miniapp detection via `isMiniApp` flag

## Testing
- [ ] Tested in regular web interface (modal still works)
- [ ] Tested in Farcaster miniapp (direct swap button works)
- [ ] Verified proper error handling for failed swaps