### PR TITLE
Add date range filter on leaderboard page

### DIFF
--- a/src/pages/leaderboard.tsx
+++ b/src/pages/leaderboard.tsx
@@ -1,8 +1,20 @@
 import Head from "next/head";
 import { type NextPage } from "next";
+import { useState } from "react";
 import LeaderboardList from "~/components/LeaderboardList";
 
 const LeaderboardPage: NextPage = () => {
+  const [startDate, setStartDate] = useState<string>("");
+  const [endDate, setEndDate] = useState<string>("");
+  const [refetchTimestamp, setRefetchTimestamp] = useState(0);
+
+  const applyDates = () => {
+    setRefetchTimestamp(Date.now());
+  };
+
+  const startDateObj = startDate ? new Date(startDate) : undefined;
+  const endDateObj = endDate ? new Date(endDate) : undefined;
+
   return (
     <>
       <Head>
@@ -15,7 +27,32 @@ const LeaderboardPage: NextPage = () => {
           <h1 className="flex items-center text-5xl font-extrabold tracking-tight sm:text-[5rem]">
             🌭 Leaderboard
           </h1>
-          <LeaderboardList showCurrentUser limit={10} height="500px" />
+          <div className="flex flex-col items-center gap-2 sm:flex-row">
+            <input
+              type="date"
+              className="input input-bordered"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+            />
+            <span className="hidden sm:inline">to</span>
+            <input
+              type="date"
+              className="input input-bordered"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+            />
+            <button className="btn btn-primary" onClick={applyDates}>
+              Apply
+            </button>
+          </div>
+          <LeaderboardList
+            showCurrentUser
+            limit={10}
+            height="500px"
+            startDate={startDateObj}
+            endDate={endDateObj}
+            refetchTimestamp={refetchTimestamp}
+          />
         </div>
       </main>
     </>


### PR DESCRIPTION
## Summary
- add start and end date filters to /leaderboard page

## Testing
- `npm run lint` *(fails: Invalid environment variables)*
- `npm run build` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68708715f2f88331ae7a6ba17043393e