### PR TITLE
Add admin page for GhostGraph queries

### DIFF
--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -1,0 +1,68 @@
+import Head from "next/head";
+import { useState } from "react";
+
+const defaultQuery = `query Judges($start: BigInt!, $end: BigInt!) {
+  votes(where: { votedAt_gte: $start, votedAt_lte: $end, isValid: true }) {
+    items {
+      voter
+      logId
+      votedAt
+    }
+  }
+}`;
+
+export default function AdminPage() {
+  const [query, setQuery] = useState(defaultQuery);
+  const [variables, setVariables] = useState("{\n  \"start\": 0,\n  \"end\": 0\n}");
+  const [result, setResult] = useState<string>("");
+  const [loading, setLoading] = useState(false);
+
+  const runQuery = async () => {
+    setLoading(true);
+    try {
+      const vars = variables ? JSON.parse(variables) : undefined;
+      const res = await fetch("/api/ghostgraph", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ query, variables: vars }),
+      });
+      const data = await res.json();
+      setResult(JSON.stringify(data, null, 2));
+    } catch (err) {
+      console.error(err);
+      setResult("Error running query");
+    }
+    setLoading(false);
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Admin - Log a Dog</title>
+      </Head>
+      <main className="flex min-h-screen flex-col items-center justify-center">
+        <div className="container flex flex-col gap-4 px-4 py-16 max-w-3xl">
+          <h1 className="text-5xl font-extrabold tracking-tight">Admin</h1>
+          <textarea
+            className="textarea textarea-bordered h-48"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+          <textarea
+            className="textarea textarea-bordered h-24"
+            value={variables}
+            onChange={(e) => setVariables(e.target.value)}
+          />
+          <button className="btn btn-primary w-32" onClick={() => void runQuery()} disabled={loading}>
+            {loading ? "Running..." : "Run Query"}
+          </button>
+          {result && (
+            <pre className="bg-base-200 p-4 rounded-lg overflow-auto whitespace-pre-wrap">
+              {result}
+            </pre>
+          )}
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/pages/api/ghostgraph.ts
+++ b/src/pages/api/ghostgraph.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { env } from "~/env";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", ["POST"]);
+    return res.status(405).json({ error: `Method ${req.method} not allowed` });
+  }
+
+  try {
+    const { query, variables } = req.body as { query: string; variables?: Record<string, unknown> };
+    const response = await fetch(
+      "https://api.ghostlogs.xyz/gg/pub/7a444b24-49f2-4960-8e2b-18eedc34ea4b/ghostgraph",
+      {
+        method: "POST",
+        headers: {
+          "X-GHOST-KEY": env.GHOST_PROTOCOL_API_KEY,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ query, variables }),
+      }
+    );
+
+    const data = await response.json();
+    res.status(200).json(data);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "Error fetching from Ghost Graph" });
+  }
+}


### PR DESCRIPTION
## Summary
- add API route `/api/ghostgraph` to proxy requests to Ghost Graph
- create `/admin` page with textarea for GraphQL queries

## Testing
- `npm install` *(fails: ERESOLVE could not resolve)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687090f7d454833185cf340865fe4750