### PR TITLE
Fix infinite refresh on homepage

### DIFF
--- a/src/hooks/useActiveChain.ts
+++ b/src/hooks/useActiveChain.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { type Chain } from 'thirdweb';
 
 import { DEFAULT_CHAIN } from '~/constants/chains';
@@ -6,13 +6,13 @@ import { DEFAULT_CHAIN } from '~/constants/chains';
 const useActiveChain = () => {
   const [activeChain, setActiveChain] = useState<Chain>(DEFAULT_CHAIN);
 
-  const updateActiveChain = (chainIdOrName: number | string) => {
+  const updateActiveChain = useCallback((chainIdOrName: number | string) => {
     // const chainById = SUPPORTED_CHAINS.find(chain => chain.id === chainIdOrName);
     // const chainByName = SUPPORTED_CHAINS.find(chain => chain.name === chainIdOrName);
     // setActiveChain(chainById ?? chainByName ?? DEFAULT_CHAIN);
     console.log('chainIdOrName', chainIdOrName);
     setActiveChain(DEFAULT_CHAIN); // no switching chains for now
-  }
+  }, []);
 
   return {
     activeChain,


### PR DESCRIPTION
## Summary
- stabilize updateActiveChain with `useCallback` to prevent effect loops

## Testing
- `SKIP_ENV_VALIDATION=1 npx next lint` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_6872792cba1483318fb2ccac119b53df