### PR TITLE
Fix homepage caching

### DIFF
--- a/CACHING_STRATEGY.md
+++ b/CACHING_STRATEGY.md
@@ -74,14 +74,14 @@ Implemented via Next.js middleware (`src/middleware.ts`):
 - **Auth/User-specific**: No cache (`private, no-cache`)
 
 ### Pages
-- **Static Pages** (/, /about): 5 minutes
+- **Static Pages** (/, /about): Cached indefinitely
 - **User-specific Pages**: No cache (`private, no-cache`)
 
 ## ISR (Incremental Static Regeneration)
 
 ### Homepage
-- **Revalidation**: 5 minutes (extended from 1 minute for better performance)
-- **Implementation**: `getStaticProps` with `revalidate: 300`
+- **Revalidation**: None - page is built at deploy time and not revalidated
+- **Implementation**: `getStaticProps` without a `revalidate` value
 
 ## Cache Invalidation Strategy
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -28,7 +28,8 @@ const miniAppMetadata = {
 export const getStaticProps = async () => {
   return {
     props: {},
-    revalidate: 60, // Revalidate every 60 seconds
+    // The homepage fetches dynamic data client-side so the
+    // static HTML can be cached indefinitely without revalidation
   };
 };
 


### PR DESCRIPTION
## Summary
- keep the homepage static by removing ISR revalidation
- document that static pages are cached indefinitely

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873ad29e0a4833186b60c5d509fd584