### PR TITLE
Fix environment validation loop

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,9 @@
  * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially useful
  * for Docker builds.
  */
-await import("./src/env.js");
+if (!process.env.SKIP_ENV_VALIDATION) {
+  await import("./src/env.js");
+}
 
 /** @type {import("next").NextConfig} */
 const config = {


### PR DESCRIPTION
## Summary
- skip loading `src/env.js` if `SKIP_ENV_VALIDATION` is set

## Testing
- `SKIP_ENV_VALIDATION=1 npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6873e568b6588331b0af0ea4d4ceb573