### PR TITLE
Fix homepage refresh issue

### DIFF
--- a/src/components/Attestation/Create.tsx
+++ b/src/components/Attestation/Create.tsx
@@ -110,7 +110,11 @@ export const CreateAttestation: FC<Props> = ({ onAttestationCreated }) => {
 
       // Just do a gentle invalidation - no forced refetch
       console.log('🔄 Transaction resolved, gentle cache invalidation');
-      void utils.hotdog.getAll.invalidate();
+      void Promise.all([
+        utils.hotdog.getAll.invalidate(),
+        utils.hotdog.getAllForUser.invalidate(),
+        utils.hotdog.getLeaderboard.invalidate(),
+      ]);
 
     } else if (!success && transactionId) {
       // If transaction failed, remove the optimistic update

--- a/src/components/Attestation/List.tsx
+++ b/src/components/Attestation/List.tsx
@@ -71,7 +71,6 @@ type Props = {
   attestors?: string[];
   startDate?: Date;
   endDate?: Date;
-  refetchTimestamp?: number;
   limit: number;
   address?: string;
 };

--- a/src/components/Attestation/UserList.tsx
+++ b/src/components/Attestation/UserList.tsx
@@ -15,7 +15,6 @@ type Props = {
   attestors?: string[];
   startDate?: Date;
   endDate?: Date;
-  refetchTimestamp?: number;
   limit: number;
   user: string;
 };

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -1,4 +1,4 @@
-import { useContext, type FC, useState, useEffect, useRef, useCallback } from "react";
+import { useContext, type FC, useState, useRef, useCallback } from "react";
 import { api } from "~/utils/api";
 import ActiveChainContext from "~/contexts/ActiveChain";
 import Link from "next/link";
@@ -10,10 +10,9 @@ type Props = {
   startDate?: Date;
   endDate?: Date;
   limit?: number;
-  refetchTimestamp: number;
 }
 
-export const Leaderboard: FC<Props> = ({ limit, startDate, endDate, refetchTimestamp }) => {
+export const Leaderboard: FC<Props> = ({ limit, startDate, endDate }) => {
   const limitOrDefault = limit ?? 10;
   const { activeChain } = useContext(ActiveChainContext);
   const [page, setPage] = useState(0);
@@ -30,11 +29,6 @@ export const Leaderboard: FC<Props> = ({ limit, startDate, endDate, refetchTimes
     refetchOnMount: false,
   });
 
-  useEffect(() => {
-    if (refetchTimestamp) {
-      void refetch();
-    }
-  }, [refetch, refetchTimestamp]);
 
   const { data: profiles } = api.profile.getManyByAddress.useQuery({
     chainId: activeChain.id,

--- a/src/components/LeaderboardBanner.tsx
+++ b/src/components/LeaderboardBanner.tsx
@@ -8,14 +8,12 @@ import useLeaderboardData from "~/hooks/useLeaderboardData";
 type Props = {
   startDate?: Date;
   endDate?: Date;
-  refetchTimestamp: number;
   scrollSpeed?: number; // pixels per second
 };
 
 export const LeaderboardBanner: FC<Props> = ({
   startDate,
   endDate,
-  refetchTimestamp,
   scrollSpeed = 50,
 }) => {
   const [reduceMotion, setReduceMotion] = useState(false);
@@ -29,7 +27,6 @@ export const LeaderboardBanner: FC<Props> = ({
   const { leaderboard, profiles } = useLeaderboardData({
     startDate,
     endDate,
-    refetchTimestamp,
   });
 
   if (!leaderboard || !profiles)

--- a/src/components/LeaderboardList.tsx
+++ b/src/components/LeaderboardList.tsx
@@ -9,7 +9,6 @@ export type LeaderboardListProps = {
   limit?: number;
   startDate?: Date;
   endDate?: Date;
-  refetchTimestamp?: number;
   showCurrentUser?: boolean;
   height?: string;
 };
@@ -18,7 +17,6 @@ export const LeaderboardList: FC<LeaderboardListProps> = ({
   limit = 10,
   startDate,
   endDate,
-  refetchTimestamp = 0,
   showCurrentUser = false,
   height = "400px",
 }) => {
@@ -26,7 +24,6 @@ export const LeaderboardList: FC<LeaderboardListProps> = ({
   const { leaderboard, profiles } = useLeaderboardData({
     startDate,
     endDate,
-    refetchTimestamp,
   });
 
   if (!leaderboard || !profiles)

--- a/src/hooks/useLeaderboardData.ts
+++ b/src/hooks/useLeaderboardData.ts
@@ -1,17 +1,15 @@
-import { useContext, useEffect } from "react";
+import { useContext } from "react";
 import ActiveChainContext from "~/contexts/ActiveChain";
 import { api } from "~/utils/api";
 
 export type UseLeaderboardOptions = {
   startDate?: Date;
   endDate?: Date;
-  refetchTimestamp?: number;
 };
 
 export const useLeaderboardData = ({
   startDate,
   endDate,
-  refetchTimestamp = 0,
 }: UseLeaderboardOptions) => {
   const { activeChain } = useContext(ActiveChainContext);
 
@@ -29,11 +27,6 @@ export const useLeaderboardData = ({
     },
   );
 
-  useEffect(() => {
-    if (refetchTimestamp) {
-      void refetch();
-    }
-  }, [refetch, refetchTimestamp]);
 
   const { data: profiles } = api.profile.getManyByAddress.useQuery(
     {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -34,7 +34,6 @@ export const getStaticProps = async () => {
 };
 
 export default function Home() {
-  const [refetchTimestamp, setRefetchTimestamp] = useState<number>(0);
   const [userPrefersDarkMode, setUserPrefersDarkMode] = useState<boolean>(false);
   const [mounted, setMounted] = useState(false);
 
@@ -59,7 +58,7 @@ export default function Home() {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <main className="flex min-h-screen flex-col items-center justify-center">
-        <LeaderboardBanner refetchTimestamp={refetchTimestamp} />
+        <LeaderboardBanner />
         <div className="container flex flex-col items-center justify-center gap-4 px-4 pt-8 pb-8">
           <h1 className="text-5xl font-extrabold tracking-tight sm:text-[5rem] flex items-center">
             <Image
@@ -74,21 +73,14 @@ export default function Home() {
             <p className="sm:text-lg text-sm text-center max-w-xs">{APP_DESCRIPTION}</p>
             <Link href="/faq" className="text-xs underline">wtf?</Link>
           </div>
-          <CreateAttestation
-            onAttestationCreated={() => {
-              // give the blockchain 10 seconds to confirm
-              setTimeout(() => {
-                setRefetchTimestamp(new Date().getTime())
-              }, 10000);
-            }}
-          />
+          <CreateAttestation />
           <div className="w-full max-w-md">
             <h2 className="text-2xl font-bold text-center">Leaderboard</h2>
-            <LeaderboardList refetchTimestamp={refetchTimestamp} limit={10} />
+            <LeaderboardList limit={10} />
           </div>
           <div className="w-full max-w-md">
             <h2 className="text-2xl font-bold text-center">Logs</h2>
-            <ListAttestations refetchTimestamp={refetchTimestamp} limit={10} />
+            <ListAttestations limit={10} />
           </div>
         </div>
       </main>

--- a/src/pages/leaderboard.tsx
+++ b/src/pages/leaderboard.tsx
@@ -6,10 +6,8 @@ import LeaderboardList from "~/components/LeaderboardList";
 const LeaderboardPage: NextPage = () => {
   const [startDate, setStartDate] = useState<string>("");
   const [endDate, setEndDate] = useState<string>("");
-  const [refetchTimestamp, setRefetchTimestamp] = useState(0);
-
   const applyDates = () => {
-    setRefetchTimestamp(Date.now());
+    /* Date filters simply trigger React state update */
   };
 
   const startDateObj = startDate ? new Date(startDate) : undefined;
@@ -51,7 +49,6 @@ const LeaderboardPage: NextPage = () => {
             height="500px"
             startDate={startDateObj}
             endDate={endDateObj}
-            refetchTimestamp={refetchTimestamp}
           />
         </div>
       </main>

--- a/src/pages/profile/[username].tsx
+++ b/src/pages/profile/[username].tsx
@@ -36,7 +36,6 @@ export const Profile: NextPage<{ username: string }> = ({ username }) => {
     refetchOnWindowFocus: false,
     refetchOnMount: false,
   });
-  const [refetchTimestamp, setRefetchTimestamp] = useState<number>(0);
   const [showProfileForm, setShowProfileForm] = useState<boolean>(false);
 
   // Check if this is the user's own profile
@@ -94,10 +93,9 @@ export const Profile: NextPage<{ username: string }> = ({ username }) => {
             />
           )}
           {isOwnProfile && (
-            <CreateAttestation onAttestationCreated={() => setRefetchTimestamp(new Date().getTime())} />
+            <CreateAttestation />
           )}
           <UserListAttestations
-            refetchTimestamp={refetchTimestamp}
             limit={4}
             user={data.address}
           />

--- a/src/pages/profile/address/[address].tsx
+++ b/src/pages/profile/address/[address].tsx
@@ -37,7 +37,6 @@ export const Profile: NextPage<{ address: string }> = ({ address }) => {
     refetchOnMount: false,
   });
   console.log({ data });
-  const [refetchTimestamp, setRefetchTimestamp] = useState<number>(0);
   const [showProfileForm, setShowProfileForm] = useState<boolean>(false);
 
   // Check if this is the user's own profile
@@ -95,10 +94,9 @@ export const Profile: NextPage<{ address: string }> = ({ address }) => {
             />
           )}
           {isOwnProfile && (
-            <CreateAttestation onAttestationCreated={() => setRefetchTimestamp(new Date().getTime())} />
+            <CreateAttestation />
           )}
           <UserListAttestations
-            refetchTimestamp={refetchTimestamp}
             limit={4}
             user={data.address}
           />

--- a/src/pages/profile/id/[id].tsx
+++ b/src/pages/profile/id/[id].tsx
@@ -37,7 +37,6 @@ export const Profile: NextPage<{ id: string }> = ({ id }) => {
     refetchOnMount: false,
   });
   console.log({ data });
-  const [refetchTimestamp, setRefetchTimestamp] = useState<number>(0);
   const [showProfileForm, setShowProfileForm] = useState<boolean>(false);
 
   // Check if this is the user's own profile
@@ -95,10 +94,9 @@ export const Profile: NextPage<{ id: string }> = ({ id }) => {
             />
           )}
           {isOwnProfile && (
-            <CreateAttestation onAttestationCreated={() => setRefetchTimestamp(new Date().getTime())} />
+            <CreateAttestation />
           )}
           <UserListAttestations
-            refetchTimestamp={refetchTimestamp}
             limit={4}
             user={data.address}
           />


### PR DESCRIPTION
## Summary
- remove refetchTimestamp prop plumbing throughout app
- update CreateAttestation to invalidate queries directly

## Testing
- `bun x next lint` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68764c7fbaf0833195946d203dcd744a