### PR TITLE
Add memoization to reduce re-renders

### DIFF
--- a/src/components/Attestation/Create.tsx
+++ b/src/components/Attestation/Create.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-misused-promises */
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
-import { type FC, useContext, useState, useMemo, useEffect } from 'react';
+import { type FC, useContext, useState, useMemo, useEffect, memo } from 'react';
 import { ConnectButton, TransactionButton, useActiveAccount, useActiveWallet } from "thirdweb/react";
 import ActiveChainContext from "~/contexts/ActiveChain";
 import { toast } from "react-toastify";
@@ -28,7 +28,7 @@ type Props = {
     metadata?: string;
   }) => void;
 }
-export const CreateAttestation: FC<Props> = ({ onAttestationCreated }) => {
+const CreateAttestationComponent: FC<Props> = ({ onAttestationCreated }) => {
   const { mutateAsync: logHotdog } = api.hotdog.log.useMutation();
   const utils = api.useUtils();
   const { addPendingDog, removePendingDog } = usePendingTransactionsStore();
@@ -423,3 +423,4 @@ export const CreateAttestation: FC<Props> = ({ onAttestationCreated }) => {
     </>
   )
 };
+export const CreateAttestation = memo(CreateAttestationComponent);

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -1,4 +1,4 @@
-import { useContext, type FC, useState, useRef, useCallback } from "react";
+import { memo, useContext, type FC, useState, useRef, useCallback, useMemo } from "react";
 import { api } from "~/utils/api";
 import ActiveChainContext from "~/contexts/ActiveChain";
 import Link from "next/link";
@@ -12,7 +12,7 @@ type Props = {
   limit?: number;
 }
 
-export const Leaderboard: FC<Props> = ({ limit, startDate, endDate }) => {
+const LeaderboardComponent: FC<Props> = ({ limit, startDate, endDate }) => {
   const limitOrDefault = limit ?? 10;
   const { activeChain } = useContext(ActiveChainContext);
   const [page, setPage] = useState(0);
@@ -40,8 +40,14 @@ export const Leaderboard: FC<Props> = ({ limit, startDate, endDate }) => {
   });
 
   const hasNextPage = leaderboard?.users ? leaderboard.users.length > (page + 1) * limitOrDefault : false;
-  const displayedUsers = leaderboard?.users?.slice(0, (page + 1) * limitOrDefault) ?? [];
-  const displayedHotdogs = leaderboard?.hotdogs?.slice(0, (page + 1) * limitOrDefault) ?? [];
+  const displayedUsers = useMemo(
+    () => leaderboard?.users?.slice(0, (page + 1) * limitOrDefault) ?? [],
+    [leaderboard?.users, page, limitOrDefault]
+  );
+  const displayedHotdogs = useMemo(
+    () => leaderboard?.hotdogs?.slice(0, (page + 1) * limitOrDefault) ?? [],
+    [leaderboard?.hotdogs, page, limitOrDefault]
+  );
 
   const lastElementRef = useCallback((node: HTMLDivElement | null) => {
     if (observer.current) observer.current.disconnect();
@@ -127,3 +133,4 @@ export const Leaderboard: FC<Props> = ({ limit, startDate, endDate }) => {
     </div>
   );
 };
+export const Leaderboard = memo(LeaderboardComponent);

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -1,4 +1,12 @@
-import { memo, useContext, type FC, useState, useRef, useCallback, useMemo } from "react";
+import {
+  memo,
+  useContext,
+  type FC,
+  useState,
+  useRef,
+  useCallback,
+  useMemo,
+} from "react";
 import { api } from "~/utils/api";
 import ActiveChainContext from "~/contexts/ActiveChain";
 import Link from "next/link";
@@ -10,7 +18,7 @@ type Props = {
   startDate?: Date;
   endDate?: Date;
   limit?: number;
-}
+};
 
 const LeaderboardComponent: FC<Props> = ({ limit, startDate, endDate }) => {
   const limitOrDefault = limit ?? 10;
@@ -20,51 +28,60 @@ const LeaderboardComponent: FC<Props> = ({ limit, startDate, endDate }) => {
   const [showSearch, setShowSearch] = useState(false);
   const observer = useRef<IntersectionObserver | null>(null);
 
-  const { data: leaderboard, refetch } = api.hotdog.getLeaderboard.useQuery({
-    chainId: activeChain.id,
-    ...startDate && { startDate: Math.floor(startDate.getTime() / 1000) },
-    ...endDate && { endDate: Math.floor(endDate.getTime() / 1000) },
-  }, {
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
-  });
+  const { data: leaderboard } = api.hotdog.getLeaderboard.useQuery(
+    {
+      chainId: activeChain.id,
+      ...(startDate && { startDate: Math.floor(startDate.getTime() / 1000) }),
+      ...(endDate && { endDate: Math.floor(endDate.getTime() / 1000) }),
+    },
+    {
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+    },
+  );
 
+  const { data: profiles } = api.profile.getManyByAddress.useQuery(
+    {
+      chainId: activeChain.id,
+      addresses: [...(leaderboard?.users ?? [])],
+    },
+    {
+      enabled: !!leaderboard?.users,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+    },
+  );
 
-  const { data: profiles } = api.profile.getManyByAddress.useQuery({
-    chainId: activeChain.id,
-    addresses: [...(leaderboard?.users ?? [])],
-  }, {
-    enabled: !!leaderboard?.users,
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
-  });
-
-  const hasNextPage = leaderboard?.users ? leaderboard.users.length > (page + 1) * limitOrDefault : false;
+  const hasNextPage = leaderboard?.users
+    ? leaderboard.users.length > (page + 1) * limitOrDefault
+    : false;
   const displayedUsers = useMemo(
     () => leaderboard?.users?.slice(0, (page + 1) * limitOrDefault) ?? [],
-    [leaderboard?.users, page, limitOrDefault]
+    [leaderboard?.users, page, limitOrDefault],
   );
   const displayedHotdogs = useMemo(
     () => leaderboard?.hotdogs?.slice(0, (page + 1) * limitOrDefault) ?? [],
-    [leaderboard?.hotdogs, page, limitOrDefault]
+    [leaderboard?.hotdogs, page, limitOrDefault],
   );
 
-  const lastElementRef = useCallback((node: HTMLDivElement | null) => {
-    if (observer.current) observer.current.disconnect();
-    observer.current = new IntersectionObserver(entries => {
-      if (entries[0]?.isIntersecting && hasNextPage) {
-        setPage(prev => prev + 1);
-      }
-    });
-    if (node) observer.current.observe(node);
-  }, [hasNextPage]);
-
-  if (!leaderboard || !profiles) return (
-    <div className="bg-base-200 rounded-lg w-[640px] h-72" />
+  const lastElementRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (observer.current) observer.current.disconnect();
+      observer.current = new IntersectionObserver((entries) => {
+        if (entries[0]?.isIntersecting && hasNextPage) {
+          setPage((prev) => prev + 1);
+        }
+      });
+      if (node) observer.current.observe(node);
+    },
+    [hasNextPage],
   );
+
+  if (!leaderboard || !profiles)
+    return <div className="h-72 w-[640px] rounded-lg bg-base-200" />;
 
   const filteredUsers = displayedUsers.filter((address) => {
-    const profile = profiles.find(p => p.address === address);
+    const profile = profiles.find((p) => p.address === address);
     const searchLower = searchQuery.toLowerCase();
     return (
       (profile?.username?.toLowerCase().includes(searchLower) ?? false) ||
@@ -73,32 +90,43 @@ const LeaderboardComponent: FC<Props> = ({ limit, startDate, endDate }) => {
   });
 
   return (
-    <div className="w-full max-w-2xl card bg-base-200 bg-opacity-25 backdrop-blur-sm p-4">
-      <div className="flex items-center mb-4 relative">
+    <div className="card w-full max-w-2xl bg-base-200 bg-opacity-25 p-4 backdrop-blur-sm">
+      <div className="relative mb-4 flex items-center">
         <div className="absolute right-0">
-          <button 
+          <button
             className="btn btn-ghost btn-sm"
             onClick={() => setShowSearch(!showSearch)}
           >
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+              />
             </svg>
           </button>
         </div>
-        <div className="text-2xl font-bold mx-auto">🌭 Leaderboard</div>
+        <div className="mx-auto text-2xl font-bold">🌭 Leaderboard</div>
       </div>
       {showSearch && (
         <div className="mb-4">
           <input
             type="text"
             placeholder="Search by username or address..."
-            className="w-full input input-bordered"
+            className="input input-bordered w-full"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
           />
         </div>
       )}
-      <div className="space-y-2 max-h-[500px] w-lg overflow-y-auto pr-2">
+      <div className="w-lg max-h-[500px] space-y-2 overflow-y-auto pr-2">
         {filteredUsers.map((address, index) => {
           const originalIndex = displayedUsers.indexOf(address);
           const hotdogCount = Number(displayedHotdogs[originalIndex]);
@@ -108,10 +136,15 @@ const LeaderboardComponent: FC<Props> = ({ limit, startDate, endDate }) => {
             <div
               key={address}
               ref={isLastElement ? lastElementRef : null}
-              className="flex items-center justify-between p-3 bg-base-200 bg-opacity-50 rounded-lg hover:bg-base-300 transition-colors gap-2"
+              className="flex items-center justify-between gap-2 rounded-lg bg-base-200 bg-opacity-50 p-3 transition-colors hover:bg-base-300"
             >
-              <Link href={`/profile/address/${address}`} className="flex items-center gap-3">
-                <div className="text-lg font-bold text-secondary">{originalIndex + 1}</div>
+              <Link
+                href={`/profile/address/${address}`}
+                className="flex items-center gap-3"
+              >
+                <div className="text-lg font-bold text-secondary">
+                  {originalIndex + 1}
+                </div>
                 <Avatar size="32px" address={address} />
                 <div className="font-medium">
                   <Name address={address} noLink />
@@ -125,7 +158,7 @@ const LeaderboardComponent: FC<Props> = ({ limit, startDate, endDate }) => {
           );
         })}
         {filteredUsers.length === 0 && (
-          <div className="text-center py-4 text-base-content/70">
+          <div className="py-4 text-center text-base-content/70">
             No results found
           </div>
         )}

--- a/src/components/LeaderboardBanner.tsx
+++ b/src/components/LeaderboardBanner.tsx
@@ -17,29 +17,32 @@ const LeaderboardBannerComponent: FC<Props> = ({
   scrollSpeed = 50,
 }) => {
   const [reduceMotion, setReduceMotion] = useState(false);
-  
+
   useEffect(() => {
     // Check if user prefers reduced motion
-    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
     setReduceMotion(mediaQuery.matches);
   }, []);
-  
+
   const { leaderboard, profiles } = useLeaderboardData({
     startDate,
     endDate,
   });
 
+  const users = useMemo(() => leaderboard?.users ?? [], [leaderboard?.users]);
+  const hotdogs = useMemo(
+    () => leaderboard?.hotdogs ?? [],
+    [leaderboard?.hotdogs],
+  );
+
   if (!leaderboard || !profiles)
     return <div className="h-20 w-full rounded-lg bg-base-200" />;
-
-  const users = useMemo(() => leaderboard.users ?? [], [leaderboard.users]);
-  const hotdogs = useMemo(() => leaderboard.hotdogs ?? [], [leaderboard.hotdogs]);
 
   // On mobile or with reduced motion, show a static banner with top 5
   if (reduceMotion) {
     const topUsers = users.slice(0, 5);
     const topHotdogs = hotdogs.slice(0, 5);
-    
+
     return (
       <div className="w-full overflow-x-auto bg-base-200 bg-opacity-25 backdrop-blur-sm">
         <div className="flex items-center gap-4 whitespace-nowrap p-2">

--- a/src/components/LeaderboardBanner.tsx
+++ b/src/components/LeaderboardBanner.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useState } from "react";
+import { type FC, useEffect, useState, useMemo, memo } from "react";
 import Link from "next/link";
 import { Name } from "./Profile/Name";
 import { Avatar } from "./Profile/Avatar";
@@ -11,7 +11,7 @@ type Props = {
   scrollSpeed?: number; // pixels per second
 };
 
-export const LeaderboardBanner: FC<Props> = ({
+const LeaderboardBannerComponent: FC<Props> = ({
   startDate,
   endDate,
   scrollSpeed = 50,
@@ -32,8 +32,8 @@ export const LeaderboardBanner: FC<Props> = ({
   if (!leaderboard || !profiles)
     return <div className="h-20 w-full rounded-lg bg-base-200" />;
 
-  const users = leaderboard.users ?? [];
-  const hotdogs = leaderboard.hotdogs ?? [];
+  const users = useMemo(() => leaderboard.users ?? [], [leaderboard.users]);
+  const hotdogs = useMemo(() => leaderboard.hotdogs ?? [], [leaderboard.hotdogs]);
 
   // On mobile or with reduced motion, show a static banner with top 5
   if (reduceMotion) {
@@ -142,4 +142,5 @@ export const LeaderboardBanner: FC<Props> = ({
   );
 };
 
+export const LeaderboardBanner = memo(LeaderboardBannerComponent);
 export default LeaderboardBanner;

--- a/src/components/LeaderboardList.tsx
+++ b/src/components/LeaderboardList.tsx
@@ -1,4 +1,4 @@
-import { type FC } from "react";
+import { type FC, memo } from "react";
 import Link from "next/link";
 import { Avatar } from "./Profile/Avatar";
 import { Name } from "./Profile/Name";
@@ -13,7 +13,7 @@ export type LeaderboardListProps = {
   height?: string;
 };
 
-export const LeaderboardList: FC<LeaderboardListProps> = ({
+const LeaderboardListComponent: FC<LeaderboardListProps> = ({
   limit = 10,
   startDate,
   endDate,
@@ -111,4 +111,5 @@ export const LeaderboardList: FC<LeaderboardListProps> = ({
   );
 };
 
+export const LeaderboardList = memo(LeaderboardListComponent);
 export default LeaderboardList;

--- a/src/components/Profile/Avatar.tsx
+++ b/src/components/Profile/Avatar.tsx
@@ -1,4 +1,4 @@
-import { type FC, useContext } from "react";
+import { type FC, useContext, memo } from "react";
 import { MediaRenderer } from "thirdweb/react";
 import ActiveChainContext from "~/contexts/ActiveChain";
 import { client } from "~/providers/Thirdweb";
@@ -6,7 +6,7 @@ import { api } from "~/utils/api";
 import Jazzicon, { jsNumberForAddress } from "react-jazzicon";
 import { ADDRESS_ZERO } from "thirdweb";
 
-export const Avatar: FC<{ address: string, fallbackSize?: number, size?: string }> = ({ address, fallbackSize, size }) => {
+const AvatarComponent: FC<{ address: string; fallbackSize?: number; size?: string }> = ({ address, fallbackSize, size }) => {
   const { activeChain } = useContext(ActiveChainContext);
   const { data: profile, isLoading } = api.profile.getByAddress.useQuery({
     chainId: activeChain.id,
@@ -61,4 +61,5 @@ export const Avatar: FC<{ address: string, fallbackSize?: number, size?: string 
   );
 };
 
+export const Avatar = memo(AvatarComponent);
 export default Avatar;

--- a/src/components/Profile/Name.tsx
+++ b/src/components/Profile/Name.tsx
@@ -1,12 +1,12 @@
 import Link from "next/link";
-import { type FC, useContext } from "react";
+import { type FC, useContext, memo } from "react";
 import { useActiveAccount } from "thirdweb/react";
 import ActiveChainContext from "~/contexts/ActiveChain";
 import { api } from "~/utils/api";
 import { ProfileButton } from "./Button";
 import { CheckBadgeIcon } from "@heroicons/react/24/solid";
 
-export const Name: FC<{ address: string; noLink?: boolean }> = ({ address, noLink }) => {
+const NameComponent: FC<{ address: string; noLink?: boolean }> = ({ address, noLink }) => {
   const { activeChain } = useContext(ActiveChainContext);
   const account = useActiveAccount();
   const { data: profile, isLoading } = api.profile.getByAddress.useQuery({
@@ -72,5 +72,6 @@ export const Name: FC<{ address: string; noLink?: boolean }> = ({ address, noLin
   );
 };
 
+export const Name = memo(NameComponent);
 export default Name;
 

--- a/src/components/Stake/Stake.tsx
+++ b/src/components/Stake/Stake.tsx
@@ -1,4 +1,4 @@
-import { type FC, useState, useEffect, useMemo } from "react";
+import { type FC, useState, useEffect, useMemo, memo } from "react";
 import {
   TransactionButton,
   useActiveWallet,
@@ -27,7 +27,7 @@ type Props = {
   hideTitle?: boolean;
 };
 
-export const Stake: FC<Props> = ({ onStake, hideTitle = false }) => {
+const StakeComponent: FC<Props> = ({ onStake, hideTitle = false }) => {
   const [activeTab, setActiveTab] = useState<"stake" | "unstake">("stake");
   const [amount, setAmount] = useState<string>("");
   const [percentage, setPercentage] = useState<number>(0);
@@ -523,3 +523,5 @@ export const Stake: FC<Props> = ({ onStake, hideTitle = false }) => {
     </div>
   );
 };
+
+export const Stake = memo(StakeComponent);

--- a/src/hooks/useLeaderboardData.ts
+++ b/src/hooks/useLeaderboardData.ts
@@ -13,7 +13,7 @@ export const useLeaderboardData = ({
 }: UseLeaderboardOptions) => {
   const { activeChain } = useContext(ActiveChainContext);
 
-  const { data: leaderboard, refetch } = api.hotdog.getLeaderboard.useQuery(
+  const { data: leaderboard } = api.hotdog.getLeaderboard.useQuery(
     {
       chainId: activeChain.id,
       ...(startDate
@@ -26,7 +26,6 @@ export const useLeaderboardData = ({
       refetchOnMount: false,
     },
   );
-
 
   const { data: profiles } = api.profile.getManyByAddress.useQuery(
     {


### PR DESCRIPTION
## Summary
- wrap frequently used components with `React.memo`
- memoize expensive slices in Leaderboard

## Testing
- `bun run lint` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_6876a06d87e08331868cfb0ddbc7c4ed