### PR TITLE
Fix infinite rerender risk

### DIFF
--- a/src/providers/Farcaster.tsx
+++ b/src/providers/Farcaster.tsx
@@ -120,7 +120,7 @@ export const FarcasterProvider = ({
       setIsSDKLoaded(true);
       void load();
     }
-  }, [isSDKLoaded]);
+  }, [sdk, isSDKLoaded]);
 
   // Separate effect for wallet connection after context is loaded
   useEffect(() => {


### PR DESCRIPTION
## Summary
- include the `sdk` object in the Farcaster provider `useEffect` dependency list

## Testing
- `npm run lint` *(fails: Invalid environment variables)*
- `npm run build` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_6878587e9ac08331a734ae9e628e2f9b