### PR TITLE
Fix countdown state initialization

### DIFF
--- a/src/components/Attestation/VotingCountdown.tsx
+++ b/src/components/Attestation/VotingCountdown.tsx
@@ -88,7 +88,7 @@ export const VotingCountdown: FC<Props> = ({
     return "Expired";
   }, [timestamp]);
 
-  const [timeLeft, setTimeLeft] = useState(calculateTimeLeft);
+  const [timeLeft, setTimeLeft] = useState(() => calculateTimeLeft());
   const [isRewardingModerators, setIsRewardingModerators] = useState(false);
   const componentId = useRef(`countdown-${logId ?? timestamp}-${Math.random()}`);
   


### PR DESCRIPTION
## Summary
- fix countdown initial state value so `timeLeft` contains the countdown string on mount

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68785c9225c483318ddd75218f57cda1