### PR TITLE
Fix potential re-renders from Zustand store

### DIFF
--- a/src/components/Attestation/List.tsx
+++ b/src/components/Attestation/List.tsx
@@ -81,7 +81,10 @@ export const ListAttestations: FC<Props> = ({ limit }) => {
   const [start, setStart] = useState<number>(0);
   const [isClient, setIsClient] = useState(false);
   const [isPaginating, setIsPaginating] = useState(false);
-  const { getPendingDogsForChain, clearExpiredPending } = usePendingTransactionsStore();
+  const clearExpiredPending = usePendingTransactionsStore(state => state.clearExpiredPending);
+  const pendingDogs = usePendingTransactionsStore(state =>
+    state.getPendingDogsForChain(activeChain.id.toString())
+  );
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const paginationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -104,8 +107,6 @@ export const ListAttestations: FC<Props> = ({ limit }) => {
     refetchOnReconnect: false,
   });
 
-  // Get pending dogs for current chain
-  const pendingDogs = getPendingDogsForChain(activeChain.id.toString());
 
   // Clear expired pending transactions more frequently
   useEffect(() => {


### PR DESCRIPTION
## Summary
- avoid subscribing to entire store in `ListAttestations`
- select only the required parts from the zustand store to avoid unnecessary re-renders

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'next' / others)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68785c9225c483318ddd75218f57cda1