### PR TITLE
Fix Farcaster wallet reconnection loop

### DIFF
--- a/src/providers/Farcaster.tsx
+++ b/src/providers/Farcaster.tsx
@@ -127,7 +127,7 @@ export const FarcasterProvider = ({
     if (context && sdk.wallet && isSDKLoaded && !hasConnectedWallet) {
       void connectWallet().then(() => setHasConnectedWallet(true));
     }
-  }, [context, isSDKLoaded, connectWallet, hasConnectedWallet]);
+  }, [context, isSDKLoaded, hasConnectedWallet]);
 
   const value = useMemo(
     () => ({


### PR DESCRIPTION
## Summary
- adjust Farcaster provider effect dependencies to avoid repeated wallet connections

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68785c9225c483318ddd75218f57cda1