### PR TITLE
Fix useEffect dependencies to avoid rerender loops

### DIFF
--- a/src/components/Attestation/UserList.tsx
+++ b/src/components/Attestation/UserList.tsx
@@ -42,7 +42,7 @@ export const UserListAttestations: FC<Props> = ({ user, limit }) => {
   useEffect(() => {
     if (!account) return;
     void refetchDogData();
-  }, [account, refetchDogData]);
+  }, [account]);
 
   // Handle pagination loading state
   useEffect(() => {

--- a/src/components/Stake/Stake.tsx
+++ b/src/components/Stake/Stake.tsx
@@ -49,7 +49,7 @@ const StakeComponent: FC<Props> = ({ onStake, hideTitle = false }) => {
     if (account?.address) {
       void refetch();
     }
-  }, [account?.address, refetch]);
+  }, [account?.address]);
 
   const { data: stakedAmount, isLoading: isLoadingStaked } = useReadContract({
     contract: getContract({


### PR DESCRIPTION
## Summary
- stop including refetch callbacks in useEffect dependency arrays

## Testing
- `SKIP_ENV_VALIDATION=true bun run lint`
- `NEXT_PUBLIC_THIRDWEB_CLIENT_ID=dummy SKIP_ENV_VALIDATION=true bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68786b5ad7408331a4dd1ea3cdaec826