### PR TITLE
Fix wallet connection loop in Farcaster provider

### DIFF
--- a/src/providers/Farcaster.tsx
+++ b/src/providers/Farcaster.tsx
@@ -125,7 +125,14 @@ export const FarcasterProvider = ({
   // Separate effect for wallet connection after context is loaded
   useEffect(() => {
     if (context && sdk.wallet && isSDKLoaded && !hasConnectedWallet) {
-      void connectWallet().then(() => setHasConnectedWallet(true));
+      void connectWallet()
+        .then(() => setHasConnectedWallet(true))
+        .catch((err) => {
+          console.error("Failed to connect wallet", err);
+          // Prevent repeated connection attempts that can cause re-renders
+          setHasConnectedWallet(true);
+          toast.error("Failed to connect wallet");
+        });
     }
   }, [context, isSDKLoaded, connectWallet, hasConnectedWallet]);
 


### PR DESCRIPTION
## Summary
- prevent repeated connection attempts if wallet connection fails by catching errors in `FarcasterProvider`

## Testing
- `SKIP_ENV_VALIDATION=1 npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68786b5ad7408331a4dd1ea3cdaec826