### PR TITLE
fix infinite rerender from Upload initialUrls

### DIFF
--- a/src/components/Attestation/Create.tsx
+++ b/src/components/Attestation/Create.tsx
@@ -82,6 +82,10 @@ const CreateAttestationComponent: FC<Props> = ({ onAttestationCreated }) => {
   const [transactionHash, setTransactionHash] = useState<string | undefined>();
   const [isTransactionIdResolved, setIsTransactionIdResolved] = useState<boolean>(false);
 
+  const memoInitialUpload = useMemo(() =>
+    imgUri ? [imgUri] : undefined
+  , [imgUri]);
+
   // Query for dog event when we have a transaction hash
   const { data: dogEvent } = api.hotdog.getDogEventByTransactionHash.useQuery(
     { transactionHash: transactionHash! },
@@ -322,7 +326,7 @@ const CreateAttestationComponent: FC<Props> = ({ onAttestationCreated }) => {
                 if (!uris) return;
                 setImgUri(uris[0]);
               }}
-              initialUrls={imgUri ? [imgUri] : undefined}
+              initialUrls={memoInitialUpload}
               onUploadError={() => {
                 // close the modal
                 (document.getElementById('create_attestation_modal') as HTMLDialogElement).close();

--- a/src/components/Profile/Form.tsx
+++ b/src/components/Profile/Form.tsx
@@ -91,6 +91,10 @@ export const ProfileForm: FC<Props> = ({ onProfileSaved, existingUsername, exist
 
   if (!wallet) return null;
 
+  const memoInitialUrls = useMemo(() =>
+    imgUrl ? [withGateway(imgUrl)] : []
+  , [imgUrl]);
+
   return (
     <div className="flex flex-col items-center gap-2">
       <div className="flex items-center h-24 w-24 rounded-full">
@@ -99,7 +103,7 @@ export const ProfileForm: FC<Props> = ({ onProfileSaved, existingUsername, exist
           label="📷 avatar"
           additionalClasses="rounded-full"
           imageClassName="rounded-full"
-          initialUrls={imgUrl ? [withGateway(imgUrl)] : []}
+          initialUrls={memoInitialUrls}
           onUpload={({ uris }) => {
             setImgUrl(uris[0]!);
           }}

--- a/src/components/Profile/Form.tsx
+++ b/src/components/Profile/Form.tsx
@@ -89,11 +89,12 @@ export const ProfileForm: FC<Props> = ({ onProfileSaved, existingUsername, exist
     }
   }
 
-  if (!wallet) return null;
+  const memoInitialUrls = useMemo(
+    () => (imgUrl ? [withGateway(imgUrl)] : []),
+    [imgUrl]
+  );
 
-  const memoInitialUrls = useMemo(() =>
-    imgUrl ? [withGateway(imgUrl)] : []
-  , [imgUrl]);
+  if (!wallet) return null;
 
   return (
     <div className="flex flex-col items-center gap-2">

--- a/src/components/utils/Upload.tsx
+++ b/src/components/utils/Upload.tsx
@@ -41,13 +41,14 @@ export const Upload: FC<UploadProps> = ({
   const [dropzoneLabel, setDropzoneLabel] = useState<string>(label ?? DEFAULT_UPLOAD_PHRASE);
   const safetyCheck = api.hotdog.checkForSafety.useMutation();
 
+  // Prevent re-renders when parent passes a new array reference
   useEffect(() => {
     if (initialUrls && initialUrls.length > 0) {
       setUrls(initialUrls);
     } else {
       setUrls([]);
     }
-  }, [initialUrls]);
+  }, [initialUrls?.join("|")]);
 
   const conductImageSafetyCheck = useCallback(async (file: File): Promise<boolean> => {
     // convert the file to base64 image

--- a/src/components/utils/Upload.tsx
+++ b/src/components/utils/Upload.tsx
@@ -1,5 +1,5 @@
 import { upload, resolveScheme } from "thirdweb/storage";
-import { type FC, useCallback ,useEffect, useState } from "react";
+import { type FC, useCallback ,useEffect, useState, useRef } from "react";
 import { useDropzone } from 'react-dropzone';
 import { toast } from 'react-toastify';
 import Image from "next/image";
@@ -42,13 +42,18 @@ export const Upload: FC<UploadProps> = ({
   const safetyCheck = api.hotdog.checkForSafety.useMutation();
 
   // Prevent re-renders when parent passes a new array reference
+  const prevInitialUrlsRef = useRef<string>();
   useEffect(() => {
-    if (initialUrls && initialUrls.length > 0) {
-      setUrls(initialUrls);
-    } else {
-      setUrls([]);
+    const joined = initialUrls?.join('|');
+    if (prevInitialUrlsRef.current !== joined) {
+      prevInitialUrlsRef.current = joined;
+      if (initialUrls && initialUrls.length > 0) {
+        setUrls(initialUrls);
+      } else {
+        setUrls([]);
+      }
     }
-  }, [initialUrls?.join("|")]);
+  }, [initialUrls]);
 
   const conductImageSafetyCheck = useCallback(async (file: File): Promise<boolean> => {
     // convert the file to base64 image


### PR DESCRIPTION
## Summary
- prevent Upload from rerendering when parent passes new array references
- memoize initial URLs in Profile form and Create attestation

## Testing
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68786b5ad7408331a4dd1ea3cdaec826