### PR TITLE
Use ghost subgraph to pre-fill judgement icons

### DIFF
--- a/src/components/Attestation/Judge.tsx
+++ b/src/components/Attestation/Judge.tsx
@@ -1,12 +1,13 @@
 import { HandThumbDownIcon, HandThumbUpIcon } from "@heroicons/react/24/outline";
 import { HandThumbDownIcon as HandThumDownIconFilled, HandThumbUpIcon as HandThumbUpIconFilled } from "@heroicons/react/24/solid";
-import { useState, type FC } from "react";
+import { useState, type FC, useEffect } from "react";
 import { toast } from "react-toastify";
 import { useSession } from "next-auth/react";
 import { api } from "~/utils/api";
 import { InsufficientStake } from "../Stake/InsufficientStake";
 import { Portal } from "../utils/Portal";
 import { TransactionStatus } from "../utils/TransactionStatus";
+import { useGhostVote } from "~/hooks/useGhostVote";
 
 type Props = {
   disabled?: boolean;
@@ -40,6 +41,14 @@ export const JudgeAttestation: FC<Props> = ({
   const [optimisticUserAttestation, setOptimisticUserAttestation] = useState<boolean | undefined>(userAttestation);
   const [isInsufficientStake, setIsInsufficientStake] = useState<boolean>(false);
   const [pendingTransactionId, setPendingTransactionId] = useState<string | null>(null);
+
+  const ghostVote = useGhostVote(logId, sessionData?.user?.address);
+
+  useEffect(() => {
+    if (ghostVote === null) return;
+    setOptimisticUserAttested(true);
+    setOptimisticUserAttestation(ghostVote);
+  }, [ghostVote]);
 
   const judgeMutation = api.hotdog.judge.useMutation({
     onMutate: async ({ isValid }) => {

--- a/src/components/Attestation/Judge.tsx
+++ b/src/components/Attestation/Judge.tsx
@@ -1,6 +1,6 @@
 import { HandThumbDownIcon, HandThumbUpIcon } from "@heroicons/react/24/outline";
 import { HandThumbDownIcon as HandThumDownIconFilled, HandThumbUpIcon as HandThumbUpIconFilled } from "@heroicons/react/24/solid";
-import { useState, type FC, useEffect } from "react";
+import { useState, type FC } from "react";
 import { toast } from "react-toastify";
 import { useSession } from "next-auth/react";
 import { api } from "~/utils/api";
@@ -44,11 +44,9 @@ export const JudgeAttestation: FC<Props> = ({
 
   const ghostVote = useGhostVote(logId, sessionData?.user?.address);
 
-  useEffect(() => {
-    if (ghostVote === null) return;
-    setOptimisticUserAttested(true);
-    setOptimisticUserAttestation(ghostVote);
-  }, [ghostVote]);
+  // Derive the effective values during render instead of using useEffect
+  const effectiveUserAttested = ghostVote !== null ? true : optimisticUserAttested;
+  const effectiveUserAttestation = ghostVote !== null ? ghostVote : optimisticUserAttestation;
 
   const judgeMutation = api.hotdog.judge.useMutation({
     onMutate: async ({ isValid }) => {
@@ -93,7 +91,7 @@ export const JudgeAttestation: FC<Props> = ({
     isValid ? setIsLoadingValidAttestation(true) : setIsLoadingInvalidValidAttestation(true);
     
     // undo attestations if the user has already attested
-    if (optimisticUserAttested && optimisticUserAttestation === isValid) {
+    if (effectiveUserAttested && effectiveUserAttestation === isValid) {
       return void revoke(isValid);
     }
 
@@ -178,7 +176,7 @@ export const JudgeAttestation: FC<Props> = ({
           ) : (
             (optimisticValidCount ?? 0).toString()
           )}
-          {optimisticUserAttested && optimisticUserAttestation === true ? (
+          {effectiveUserAttested && effectiveUserAttestation === true ? (
             <HandThumbUpIconFilled className="w-4 h-4" />
           ) : (
             <HandThumbUpIcon className="w-4 h-4" />
@@ -188,7 +186,7 @@ export const JudgeAttestation: FC<Props> = ({
           className="btn btn-xs btn-circle btn-ghost w-fit px-2"
           onClick={() => attest(false)}
         >
-          {optimisticUserAttested && optimisticUserAttestation === false ? (
+          {effectiveUserAttested && effectiveUserAttestation === false ? (
             <HandThumDownIconFilled className="w-4 h-4" />
           ) : (
             <HandThumbDownIcon className="w-4 h-4" />

--- a/src/components/Attestation/Judge.tsx
+++ b/src/components/Attestation/Judge.tsx
@@ -45,8 +45,8 @@ export const JudgeAttestation: FC<Props> = ({
   const ghostVote = useGhostVote(logId, sessionData?.user?.address);
 
   // Derive the effective values during render instead of using useEffect
-  const effectiveUserAttested = ghostVote !== null ? true : optimisticUserAttested;
-  const effectiveUserAttestation = ghostVote !== null ? ghostVote : optimisticUserAttestation;
+  const effectiveUserAttested = ghostVote ?? optimisticUserAttested;
+  const effectiveUserAttestation = ghostVote ?? optimisticUserAttestation;
 
   const judgeMutation = api.hotdog.judge.useMutation({
     onMutate: async ({ isValid }) => {

--- a/src/hooks/useGhostVote.ts
+++ b/src/hooks/useGhostVote.ts
@@ -1,0 +1,17 @@
+import { useMemo } from "react";
+import { api } from "~/utils/api";
+
+export function useGhostVote(logId: string | undefined, voter: string | undefined) {
+  const { data: votes } = api.ghost.getUserVotes.useQuery(
+    { voter: voter ?? "" },
+    {
+      enabled: !!voter,
+      staleTime: Infinity,
+    },
+  );
+
+  return useMemo(() => {
+    if (!logId || !votes) return null;
+    return votes[logId] ?? null;
+  }, [logId, votes]);
+}


### PR DESCRIPTION
## Summary
- add cached tRPC endpoint `getUserVotes` to fetch all Ghost votes for a user
- update `useGhostVote` hook to consume this cached endpoint
- Judge component now pre-fills vote icons using cached Ghost data

## Testing
- `npm run lint` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_6875d1fba1f08331b788c96d49af717e