### PR TITLE
Fix continuous refresh after login

### DIFF
--- a/src/components/utils/Connect.tsx
+++ b/src/components/utils/Connect.tsx
@@ -125,6 +125,7 @@ export const Connect: FC<Props> = ({ loginBtnLabel }) => {
             message,
             signature: params.signature,
             address: params.payload.address,
+            redirect: false,
           });
         },
         getLoginPayload: async ({ address }) =>


### PR DESCRIPTION
## Summary
- prevent redirects when Connect button performs login

## Testing
- `SKIP_ENV_VALIDATION=1 npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687940421ad88331af60083ae82883e7