### PR TITLE
Add duplicate image detection

### DIFF
--- a/src/components/Attestation/List.tsx
+++ b/src/components/Attestation/List.tsx
@@ -63,6 +63,7 @@ type RealDogEvent = {
   zoraCoin: ZoraCoinDetails | null;
   attestationPeriod?: AttestationPeriod;
   metadata?: HotdogMetadata | null;
+  duplicateOfLogId?: string | null;
 };
 
 type HotdogItem = RealDogEvent | PendingDogEvent;

--- a/src/components/utils/HotdogCard.tsx
+++ b/src/components/utils/HotdogCard.tsx
@@ -254,20 +254,18 @@ export const HotdogCard: FC<Props> = ({
           </div>
         </div>
 
-        {/* Image */}
-        {ImageComponent}
-
-        {/* Duplicate image tag row */}
-        {hotdog.duplicateOfLogId && (
-          <div className="flex w-full justify-end">
+        {/* Image with duplicate badge overlay */}
+        <div className="relative">
+          {ImageComponent}
+          {hotdog.duplicateOfLogId && (
             <Link
               href={`/dog/${hotdog.duplicateOfLogId}`}
-              className="badge badge-warning"
+              className="badge badge-warning absolute right-2 top-2"
             >
               Duplicate Image
             </Link>
-          </div>
-        )}
+          )}
+        </div>
 
         {/* Bottom section with attestation info and actions */}
         <div className="flex w-full flex-row items-center justify-between opacity-50">

--- a/src/components/utils/HotdogCard.tsx
+++ b/src/components/utils/HotdogCard.tsx
@@ -71,6 +71,7 @@ type HotdogData = {
   zoraCoin: ZoraCoinDetails | string | null; // Can be object, string, or null
   attestationPeriod?: AttestationPeriod;
   isPending?: boolean;
+  duplicateOfLogId?: string | null;
 };
 
 type Props = {
@@ -268,6 +269,14 @@ export const HotdogCard: FC<Props> = ({
                 <TagIcon className="h-4 w-4" />
                 {hotdog.logId.toString()}
               </>
+            )}
+            {hotdog.duplicateOfLogId && (
+              <Link
+                href={`/dog/${hotdog.duplicateOfLogId}`}
+                className="badge badge-warning ml-2"
+              >
+                Duplicate Image
+              </Link>
             )}
           </div>
           <div className="flex items-center justify-end gap-2 text-xs">

--- a/src/components/utils/HotdogCard.tsx
+++ b/src/components/utils/HotdogCard.tsx
@@ -257,6 +257,18 @@ export const HotdogCard: FC<Props> = ({
         {/* Image */}
         {ImageComponent}
 
+        {/* Duplicate image tag row */}
+        {hotdog.duplicateOfLogId && (
+          <div className="flex w-full justify-end">
+            <Link
+              href={`/dog/${hotdog.duplicateOfLogId}`}
+              className="badge badge-warning"
+            >
+              Duplicate Image
+            </Link>
+          </div>
+        )}
+
         {/* Bottom section with attestation info and actions */}
         <div className="flex w-full flex-row items-center justify-between opacity-50">
           <div className="flex items-center gap-1 text-xs">
@@ -269,14 +281,6 @@ export const HotdogCard: FC<Props> = ({
                 <TagIcon className="h-4 w-4" />
                 {hotdog.logId.toString()}
               </>
-            )}
-            {hotdog.duplicateOfLogId && (
-              <Link
-                href={`/dog/${hotdog.duplicateOfLogId}`}
-                className="badge badge-warning ml-2"
-              >
-                Duplicate Image
-              </Link>
             )}
           </div>
           <div className="flex items-center justify-end gap-2 text-xs">

--- a/src/components/utils/HotdogCard.tsx
+++ b/src/components/utils/HotdogCard.tsx
@@ -176,7 +176,7 @@ export const HotdogCard: FC<Props> = ({
   const ImageComponent = linkToDetail ? (
     <Link
       href={`/dog/${hotdog.logId}`}
-      className="flex w-full items-center justify-center"
+      className={`flex w-full items-center justify-center ${hotdog.duplicateOfLogId ? "opacity-50" : ""}`}
     >
       <HotdogImage
         src={hotdog.imageUri}
@@ -260,7 +260,7 @@ export const HotdogCard: FC<Props> = ({
           {hotdog.duplicateOfLogId && (
             <Link
               href={`/dog/${hotdog.duplicateOfLogId}`}
-              className="badge badge-warning absolute right-2 top-2"
+              className="badge badge-warning absolute right-4 top-4"
             >
               Duplicate Image
             </Link>


### PR DESCRIPTION
## Summary
- mark duplicate images in API and show a badge linking to the original
- surface duplicate data in hotdog listings and detail view

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879551afe348331becdfafdbe2c2c1a