### PR TITLE
Fix repeated wallet connection attempts

### DIFF
--- a/src/providers/Farcaster.tsx
+++ b/src/providers/Farcaster.tsx
@@ -69,8 +69,10 @@ export const FarcasterProvider = ({
         // return the wallet to the app context
         return wallet;
       });
+      return true;
     } catch (err) {
       console.error("Failed to connect wallet", err);
+      return false;
     }
   }, [connect]);
 
@@ -123,7 +125,14 @@ export const FarcasterProvider = ({
   // Separate effect for wallet connection after context is loaded
   useEffect(() => {
     if (context && sdk.wallet && isSDKLoaded && !hasConnectedWallet) {
-      void connectWallet().then(() => setHasConnectedWallet(true));
+      const attemptConnect = async () => {
+        const success = await connectWallet();
+        if (!success) {
+          console.warn("Wallet connection failed, disabling further attempts");
+        }
+        setHasConnectedWallet(true);
+      };
+      void attemptConnect();
     }
   }, [context, isSDKLoaded, connectWallet, hasConnectedWallet]);
 


### PR DESCRIPTION
## Summary
- avoid repeated connection attempts in `FarcasterProvider` by stopping retries on failure

## Testing
- `npm run lint` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_687ae2681e8c83319aa2cf6c0a713382