### PR TITLE
Fix rerender loop on homepage

### DIFF
--- a/src/components/utils/Connect.tsx
+++ b/src/components/utils/Connect.tsx
@@ -143,7 +143,8 @@ export const Connect: FC<Props> = ({ loginBtnLabel }) => {
         getLoginPayload: async ({ address }) =>
           createPayload({ address }),
         doLogout: async () => {
-          await signOut();
+          // Avoid redirect loops by disabling the default signOut redirect
+          await signOut({ redirect: false });
         },
       }}
       connectModal={{


### PR DESCRIPTION
## Summary
- fix signout logic to avoid redirect loops when a session exists but no wallet is connected

## Testing
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_e_687aeb1d3db08331ae696d440488d89d