### PR TITLE
Fix wallet auth refresh loop

### DIFF
--- a/src/components/utils/Connect.tsx
+++ b/src/components/utils/Connect.tsx
@@ -125,6 +125,11 @@ export const Connect: FC<Props> = ({ loginBtnLabel }) => {
       }}
       auth={{
         isLoggedIn: async () => {
+          // Avoid triggering auth flow while the session status is loading
+          if (status === 'loading') {
+            return true;
+          }
+
           // Only consider logged in if there's both a session AND a wallet connected
           // This prevents state mismatches that cause infinite refreshes
           if (sessionData?.user?.id && account?.address) {


### PR DESCRIPTION
## Summary
- guard auth.isLoggedIn while session state loads

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b09679f948331bee21659bc495fbe