### PR TITLE
Refactor: reduce useEffect usage

### DIFF
--- a/src/components/LeaderboardBanner.tsx
+++ b/src/components/LeaderboardBanner.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useState, useMemo, memo } from "react";
+import { type FC, useState, useMemo, memo } from "react";
 import Link from "next/link";
 import { Name } from "./Profile/Name";
 import { Avatar } from "./Profile/Avatar";
@@ -16,13 +16,10 @@ const LeaderboardBannerComponent: FC<Props> = ({
   endDate,
   scrollSpeed = 50,
 }) => {
-  const [reduceMotion, setReduceMotion] = useState(false);
-
-  useEffect(() => {
-    // Check if user prefers reduced motion
-    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
-    setReduceMotion(mediaQuery.matches);
-  }, []);
+  const [reduceMotion] = useState<boolean>(() =>
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+  );
 
   const { leaderboard, profiles } = useLeaderboardData({
     startDate,

--- a/src/components/utils/Buy.tsx
+++ b/src/components/utils/Buy.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState, type FC } from "react";
+import { useContext, useState, type FC } from "react";
 import { darkTheme, lightTheme, BuyWidget } from "thirdweb/react";
 import { client } from "~/providers/Thirdweb";
 import { Portal } from "./Portal";
@@ -9,10 +9,10 @@ import { FarcasterContext } from "~/providers/Farcaster";
 export const Buy: FC = () => {
   const farcaster = useContext(FarcasterContext);
   const isMiniApp = farcaster?.isMiniApp ?? false;
-  const [userPrefersDarkMode, setUserPrefersDarkMode] = useState<boolean>(false);
-  useEffect(() => {
-    setUserPrefersDarkMode(window.matchMedia('(prefers-color-scheme: dark)').matches);
-  }, []);
+  const [userPrefersDarkMode] = useState<boolean>(() =>
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches,
+  );
 
   const handleMiniAppBuy = async () => {
     if (!farcaster?.context) return;

--- a/src/components/utils/Connect.tsx
+++ b/src/components/utils/Connect.tsx
@@ -1,4 +1,4 @@
-import { type FC, useState, useEffect, useCallback, useRef } from "react";
+import { type FC, useState, useCallback, useRef } from "react";
 import { ConnectButton, useActiveAccount } from "thirdweb/react";
 import { client } from "~/providers/Thirdweb";
 import { createWallet, inAppWallet, type Wallet, walletConnect } from "thirdweb/wallets";
@@ -18,12 +18,9 @@ export const Connect: FC<Props> = ({ loginBtnLabel }) => {
   const account = useActiveAccount();
   const sessionDataRef = useRef<typeof sessionData>(null);
   const statusRef = useRef<typeof status>('loading');
-
-  // Update refs when session data changes
-  useEffect(() => {
-    sessionDataRef.current = sessionData;
-    statusRef.current = status;
-  }, [sessionData, status]);
+  // keep refs in sync without triggering effects
+  sessionDataRef.current = sessionData;
+  statusRef.current = status;
 
   useEffect(() => {
     setMounted(true);

--- a/src/components/utils/HotdogImage.tsx
+++ b/src/components/utils/HotdogImage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type FC } from "react";
+import { useMemo, useState, type FC } from "react";
 import Image from "next/image";
 import { MediaRenderer } from "thirdweb/react";
 import { client } from "~/providers/Thirdweb";
@@ -161,15 +161,10 @@ export const HotdogImage: FC<Props> = ({ src, zoraCoin, className, width, height
   const coin = typeof zoraCoin === "object" && zoraCoin !== null && "mediaContent" in zoraCoin ? zoraCoin as { mediaContent?: { previewImage?: { medium?: string; blurhash?: string } } } : undefined;
   const preview = coin?.mediaContent?.previewImage?.medium;
   const blurhash = coin?.mediaContent?.previewImage?.blurhash;
-  const [blurDataURL, setBlurDataURL] = useState<string>();
-  const [imageError, setImageError] = useState(false);
-
-  useEffect(() => {
-    if (blurhash) {
-      const url = blurhashToDataURL(blurhash);
-      if (url) setBlurDataURL(url);
-    }
+  const blurDataURL = useMemo(() => {
+    return blurhash ? blurhashToDataURL(blurhash) : undefined;
   }, [blurhash]);
+  const [imageError, setImageError] = useState(false);
 
   if (preview) {
     return (

--- a/src/components/utils/Layout.tsx
+++ b/src/components/utils/Layout.tsx
@@ -1,4 +1,4 @@
-import { type FC, type ReactNode,useEffect, useState } from "react"
+import { type FC, type ReactNode, useState } from "react"
 import { useRouter } from "next/router";
 import Link from "next/link";
 import { BottomNav } from "./BottomNav";
@@ -10,13 +10,11 @@ interface LayoutProps {
 export const Layout: FC<LayoutProps> = ({ children }) => {
   const router = useRouter();
 
-  const [userPrefersDarkMode, setUserPrefersDarkMode] = useState<boolean>(false);
-  const [mounted, setMounted] = useState(false);
-  
-  useEffect(() => {
-    setMounted(true);
-    setUserPrefersDarkMode(window.matchMedia('(prefers-color-scheme: dark)').matches);
-  }, []);
+  const [userPrefersDarkMode] = useState<boolean>(() =>
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches,
+  );
+  const mounted = typeof window !== 'undefined';
 
   // Prevent hydration mismatch by not applying dark mode styles until mounted
   const fromYellow = mounted && userPrefersDarkMode ? "from-yellow-300" : "from-yellow-100";

--- a/src/components/utils/Portal.tsx
+++ b/src/components/utils/Portal.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode,useEffect, useRef, useState } from 'react';
+import { type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
 interface PortalProps {
@@ -6,13 +6,12 @@ interface PortalProps {
 }
 
 export const Portal = (props: PortalProps) => {
-  const ref = useRef<Element | null>(null);
-  const [mounted, setMounted] = useState<boolean>(false);
-  
-  useEffect(() => {
-    ref.current = document.querySelector<HTMLElement>("#portal")
-    setMounted(true)
-  }, []);
+  const portalElement =
+    typeof document !== 'undefined'
+      ? document.querySelector<HTMLElement>('#portal')
+      : null;
 
-  return (mounted && ref.current) ? createPortal(<div>{props.children}</div>, ref.current) : null
+  return portalElement
+    ? createPortal(<div>{props.children}</div>, portalElement)
+    : null;
 }

--- a/src/components/utils/SignIn.tsx
+++ b/src/components/utils/SignIn.tsx
@@ -1,6 +1,6 @@
 import { CheckIcon } from '@heroicons/react/24/outline';
 import { getCsrfToken, signIn, useSession } from 'next-auth/react';
-import React, { type FC, useState, useEffect } from 'react';
+import React, { type FC, useState } from 'react';
 import { SiweMessage } from 'siwe';
 import { useActiveAccount } from 'thirdweb/react';
 import { signMessage } from "thirdweb/utils";
@@ -14,19 +14,10 @@ const SignInWithEthereum: FC<Props> = ({ btnLabel, defaultOpen = false }) => {
   const { data: sessionData, status } = useSession();
   const account = useActiveAccount();
   const [isSigningIn, setIsSigningIn] = useState<boolean>(false);
+  const [internalOpen, setInternalOpen] = useState(false);
 
-  useEffect(() => {
-    if (defaultOpen && !sessionData?.user && status !== 'loading') {
-      (document.getElementById(`sign_in_modal`) as HTMLDialogElement)?.showModal();
-    }
-  }, [defaultOpen, sessionData?.user, status]);
-
-  // close the modal if the user is signed in
-  useEffect(() => {
-    if (sessionData?.user) {
-      (document.getElementById(`sign_in_modal`) as HTMLDialogElement)?.close();
-    }
-  }, [sessionData?.user]);
+  const isOpen =
+    internalOpen || (defaultOpen && !sessionData?.user && status !== 'loading');
  
   const promptToSign = async () => {
     if (!account?.address) return;
@@ -54,10 +45,10 @@ const SignInWithEthereum: FC<Props> = ({ btnLabel, defaultOpen = false }) => {
         redirect: false,
       });
 
-
       if (response?.error) {
         throw new Error(response.error);
       }
+      setInternalOpen(false);
     } catch (e) {
       console.error('Error signing in:', e);
     } finally {
@@ -67,15 +58,14 @@ const SignInWithEthereum: FC<Props> = ({ btnLabel, defaultOpen = false }) => {
   if (sessionData?.user) return null;
   return (
     <>
-    {/* Open the modal using document.getElementById('ID').showModal() method */}
-    <button className="btn" onClick={()=>(document.getElementById(`sign_in_modal`) as HTMLDialogElement).showModal()}>
+    <button className="btn" onClick={() => setInternalOpen(true)}>
       {`${btnLabel ?? 'Vow to play with honor'}`}
     </button>
-    <dialog id={`sign_in_modal`} className="modal">
+    <dialog id={`sign_in_modal`} className="modal" open={isOpen}>
       <div className="modal-box relative">
-        <button 
+        <button
           className="btn btn-circle btn-sm btn-ghost absolute top-4 right-4"
-          onClick={()=>(document.getElementById(`sign_in_modal`) as HTMLDialogElement).close()}
+          onClick={() => setInternalOpen(false)}
         >
           &times;
         </button>

--- a/src/hooks/useIsOnMobileSafari.ts
+++ b/src/hooks/useIsOnMobileSafari.ts
@@ -1,21 +1,15 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 const useIsOnMobileSafari = () => {
-  const [isMounted, setIsMounted] = useState<boolean>(false);
-  
   const isOnMobileSafari = useMemo(() => {
-    if (!isMounted) return false;
+    if (typeof navigator === 'undefined') return false;
     const ua = navigator.userAgent;
     const iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);
     const webkit = !!ua.match(/WebKit/i);
     const iOSSafari = iOS && webkit && !ua.match(/CriOS/i);
     return iOSSafari;
-  }, [isMounted]);
-
-  useEffect(() => {
-    setIsMounted(true);
   }, []);
-  
+
   return {
     isOnMobileSafari,
   }

--- a/src/hooks/usePrevious.ts
+++ b/src/hooks/usePrevious.ts
@@ -1,12 +1,11 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function usePrevious(value: any) {
   const ref = useRef();
-  useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    ref.current = value; //assign the value of ref to the argument
-  },[value]); //this code will run when the value of 'value' changes
-  return ref.current; //in the end, return the current ref value.
+  const previous = ref.current;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  ref.current = value;
+  return previous; // return the previous value on each render
 }
 export default usePrevious;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import Head from "next/head";
 import Link from "next/link";
 // import Link from "next/link";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { CreateAttestation } from "~/components/Attestation/Create";
 import { ListAttestations } from "~/components/Attestation/List";
 import { LeaderboardBanner } from "~/components/LeaderboardBanner";
@@ -34,15 +34,11 @@ export const getStaticProps = async () => {
 };
 
 export default function Home() {
-  const [userPrefersDarkMode, setUserPrefersDarkMode] = useState<boolean>(false);
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-    setUserPrefersDarkMode(
-      window.matchMedia("(prefers-color-scheme: dark)").matches,
-    );
-  }, []);
+  const [userPrefersDarkMode] = useState<boolean>(() =>
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches,
+  );
+  const mounted = typeof window !== 'undefined';
 
   const bannerSrc =
     mounted && userPrefersDarkMode


### PR DESCRIPTION
## Summary
- remove unnecessary `useEffect` usage across hooks and components
- compute dark mode & motion preference on mount without effects
- simplify portal creation logic
- convert blurhash decoding to `useMemo`
- derive modal state without effects

## Testing
- `npm install` *(fails: unable to resolve dependency tree)*

------
https://chatgpt.com/codex/tasks/task_e_687b9f9f65c88331a3def62ff33611ea