### PR TITLE
Reduce useEffect hooks

### DIFF
--- a/src/components/Attestation/List.tsx
+++ b/src/components/Attestation/List.tsx
@@ -79,16 +79,12 @@ type Props = {
 export const ListAttestations: FC<Props> = ({ limit }) => {
   const limitOrDefault = limit ?? 4;
   const [start, setStart] = useState<number>(0);
-  const [isClient, setIsClient] = useState(false);
+  const isClient = typeof window !== 'undefined';
   const [isPaginating, setIsPaginating] = useState(false);
   const { getPendingDogsForChain, clearExpiredPending } = usePendingTransactionsStore();
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const paginationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Fix hydration mismatch by only rendering dynamic content on client
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
 
   const queryParams = {
     chainId: DEFAULT_CHAIN.id,

--- a/src/components/LeaderboardBanner.tsx
+++ b/src/components/LeaderboardBanner.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useState, useMemo, memo } from "react";
+import { type FC, useMemo, memo } from "react";
 import Link from "next/link";
 import { Name } from "./Profile/Name";
 import { Avatar } from "./Profile/Avatar";
@@ -16,13 +16,9 @@ const LeaderboardBannerComponent: FC<Props> = ({
   endDate,
   scrollSpeed = 50,
 }) => {
-  const [reduceMotion, setReduceMotion] = useState(false);
-
-  useEffect(() => {
-    // Check if user prefers reduced motion
-    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
-    setReduceMotion(mediaQuery.matches);
-  }, []);
+  const reduceMotion =
+    typeof window !== "undefined" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
   const { leaderboard, profiles } = useLeaderboardData({
     startDate,

--- a/src/components/utils/Buy.tsx
+++ b/src/components/utils/Buy.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState, type FC } from "react";
+import { useContext, type FC } from "react";
 import { darkTheme, lightTheme, BuyWidget } from "thirdweb/react";
 import { client } from "~/providers/Thirdweb";
 import { Portal } from "./Portal";
@@ -9,10 +9,9 @@ import { FarcasterContext } from "~/providers/Farcaster";
 export const Buy: FC = () => {
   const farcaster = useContext(FarcasterContext);
   const isMiniApp = farcaster?.isMiniApp ?? false;
-  const [userPrefersDarkMode, setUserPrefersDarkMode] = useState<boolean>(false);
-  useEffect(() => {
-    setUserPrefersDarkMode(window.matchMedia('(prefers-color-scheme: dark)').matches);
-  }, []);
+  const userPrefersDarkMode =
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches;
 
   const handleMiniAppBuy = async () => {
     if (!farcaster?.context) return;

--- a/src/components/utils/Connect.tsx
+++ b/src/components/utils/Connect.tsx
@@ -13,21 +13,20 @@ type Props = {
 
 export const Connect: FC<Props> = ({ loginBtnLabel }) => {
   const { data: sessionData, status } = useSession();
-  const [userPrefersDarkMode, setUserPrefersDarkMode] = useState<boolean>(false);
   const [mounted, setMounted] = useState(false);
+  const userPrefersDarkMode =
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches;
   const account = useActiveAccount();
   const sessionDataRef = useRef<typeof sessionData>(null);
   const statusRef = useRef<typeof status>('loading');
 
-  // Update refs when session data changes
-  useEffect(() => {
-    sessionDataRef.current = sessionData;
-    statusRef.current = status;
-  }, [sessionData, status]);
+  // Keep refs in sync without triggering effects
+  sessionDataRef.current = sessionData;
+  statusRef.current = status;
 
   useEffect(() => {
     setMounted(true);
-    setUserPrefersDarkMode(window.matchMedia('(prefers-color-scheme: dark)').matches);
   }, []);
 
   const cryptoWallets = [

--- a/src/components/utils/HotdogImage.tsx
+++ b/src/components/utils/HotdogImage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type FC } from "react";
+import { useMemo, useState, type FC } from "react";
 import Image from "next/image";
 import { MediaRenderer } from "thirdweb/react";
 import { client } from "~/providers/Thirdweb";
@@ -161,14 +161,11 @@ export const HotdogImage: FC<Props> = ({ src, zoraCoin, className, width, height
   const coin = typeof zoraCoin === "object" && zoraCoin !== null && "mediaContent" in zoraCoin ? zoraCoin as { mediaContent?: { previewImage?: { medium?: string; blurhash?: string } } } : undefined;
   const preview = coin?.mediaContent?.previewImage?.medium;
   const blurhash = coin?.mediaContent?.previewImage?.blurhash;
-  const [blurDataURL, setBlurDataURL] = useState<string>();
   const [imageError, setImageError] = useState(false);
 
-  useEffect(() => {
-    if (blurhash) {
-      const url = blurhashToDataURL(blurhash);
-      if (url) setBlurDataURL(url);
-    }
+  const blurDataURL = useMemo(() => {
+    if (!blurhash) return undefined;
+    return blurhashToDataURL(blurhash) ?? undefined;
   }, [blurhash]);
 
   if (preview) {

--- a/src/components/utils/Portal.tsx
+++ b/src/components/utils/Portal.tsx
@@ -1,18 +1,15 @@
-import { type ReactNode,useEffect, useRef, useState } from 'react';
+import { type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
 interface PortalProps {
   children: ReactNode
 }
 
-export const Portal = (props: PortalProps) => {
-  const ref = useRef<Element | null>(null);
-  const [mounted, setMounted] = useState<boolean>(false);
-  
-  useEffect(() => {
-    ref.current = document.querySelector<HTMLElement>("#portal")
-    setMounted(true)
-  }, []);
+export const Portal = ({ children }: PortalProps) => {
+  const portalElement =
+    typeof document !== 'undefined'
+      ? document.querySelector<HTMLElement>('#portal')
+      : null;
 
-  return (mounted && ref.current) ? createPortal(<div>{props.children}</div>, ref.current) : null
-}
+  return portalElement ? createPortal(<div>{children}</div>, portalElement) : null;
+};

--- a/src/components/utils/SignIn.tsx
+++ b/src/components/utils/SignIn.tsx
@@ -16,17 +16,16 @@ const SignInWithEthereum: FC<Props> = ({ btnLabel, defaultOpen = false }) => {
   const [isSigningIn, setIsSigningIn] = useState<boolean>(false);
 
   useEffect(() => {
-    if (defaultOpen && !sessionData?.user && status !== 'loading') {
-      (document.getElementById(`sign_in_modal`) as HTMLDialogElement)?.showModal();
+    const dialog = document.getElementById(
+      `sign_in_modal`,
+    ) as HTMLDialogElement | null;
+
+    if (sessionData?.user) {
+      dialog?.close();
+    } else if (defaultOpen && status !== 'loading') {
+      dialog?.showModal();
     }
   }, [defaultOpen, sessionData?.user, status]);
-
-  // close the modal if the user is signed in
-  useEffect(() => {
-    if (sessionData?.user) {
-      (document.getElementById(`sign_in_modal`) as HTMLDialogElement)?.close();
-    }
-  }, [sessionData?.user]);
  
   const promptToSign = async () => {
     if (!account?.address) return;

--- a/src/hooks/useIsOnMobileSafari.ts
+++ b/src/hooks/useIsOnMobileSafari.ts
@@ -1,24 +1,18 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 const useIsOnMobileSafari = () => {
-  const [isMounted, setIsMounted] = useState<boolean>(false);
-  
   const isOnMobileSafari = useMemo(() => {
-    if (!isMounted) return false;
+    if (typeof navigator === 'undefined') return false;
     const ua = navigator.userAgent;
     const iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);
     const webkit = !!ua.match(/WebKit/i);
     const iOSSafari = iOS && webkit && !ua.match(/CriOS/i);
     return iOSSafari;
-  }, [isMounted]);
-
-  useEffect(() => {
-    setIsMounted(true);
   }, []);
-  
+
   return {
     isOnMobileSafari,
-  }
-}
+  };
+};
 
 export default useIsOnMobileSafari;

--- a/src/hooks/usePrevious.ts
+++ b/src/hooks/usePrevious.ts
@@ -1,12 +1,10 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function usePrevious(value: any) {
-  const ref = useRef();
-  useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    ref.current = value; //assign the value of ref to the argument
-  },[value]); //this code will run when the value of 'value' changes
-  return ref.current; //in the end, return the current ref value.
+function usePrevious<T>(value: T): T | undefined {
+  const ref = useRef<T>();
+  const previous = ref.current;
+  ref.current = value;
+  return previous;
 }
 export default usePrevious;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -34,20 +34,18 @@ export const getStaticProps = async () => {
 };
 
 export default function Home() {
-  const [userPrefersDarkMode, setUserPrefersDarkMode] = useState<boolean>(false);
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     setMounted(true);
-    setUserPrefersDarkMode(
-      window.matchMedia("(prefers-color-scheme: dark)").matches,
-    );
   }, []);
 
+  const prefersDark =
+    typeof window !== "undefined" &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches;
+
   const bannerSrc =
-    mounted && userPrefersDarkMode
-      ? "/images/banner-dark.png"
-      : "/images/banner.png";
+    mounted && prefersDark ? "/images/banner-dark.png" : "/images/banner.png";
 
   return (
     <>

--- a/src/providers/Farcaster.tsx
+++ b/src/providers/Farcaster.tsx
@@ -110,6 +110,11 @@ export const FarcasterProvider = ({
         const mini = await sdk.isInMiniApp();
         setIsMiniApp(mini);
         await sdk.actions.ready({});
+
+        if (sdk.wallet && !hasConnectedWallet) {
+          await connectWallet();
+          setHasConnectedWallet(true);
+        }
       } catch (err) {
         console.error("Failed to load SDK", err);
       }
@@ -118,14 +123,7 @@ export const FarcasterProvider = ({
       setIsSDKLoaded(true);
       void load();
     }
-  }, [isSDKLoaded]);
-
-  // Separate effect for wallet connection after context is loaded
-  useEffect(() => {
-    if (context && sdk.wallet && isSDKLoaded && !hasConnectedWallet) {
-      void connectWallet().then(() => setHasConnectedWallet(true));
-    }
-  }, [context, isSDKLoaded, connectWallet, hasConnectedWallet]);
+  }, [isSDKLoaded, connectWallet, hasConnectedWallet]);
 
   const value = useMemo(
     () => ({


### PR DESCRIPTION
## Summary
- drop unnecessary `useEffect` hooks
- compute media queries directly
- refactor provider initialization
- streamline modal visibility logic

## Testing
- `npm run lint` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_687b9f9f65c88331a3def62ff33611ea