### PR TITLE
Refactor to shared preference hooks

### DIFF
--- a/src/components/LeaderboardBanner.tsx
+++ b/src/components/LeaderboardBanner.tsx
@@ -1,9 +1,10 @@
-import { type FC, useEffect, useState, useMemo, memo } from "react";
+import { type FC, useMemo, memo } from "react";
 import Link from "next/link";
 import { Name } from "./Profile/Name";
 import { Avatar } from "./Profile/Avatar";
 import styles from "./LeaderboardBanner.module.css";
 import useLeaderboardData from "~/hooks/useLeaderboardData";
+import usePrefersReducedMotion from "~/hooks/usePrefersReducedMotion";
 
 type Props = {
   startDate?: Date;
@@ -16,13 +17,7 @@ const LeaderboardBannerComponent: FC<Props> = ({
   endDate,
   scrollSpeed = 50,
 }) => {
-  const [reduceMotion, setReduceMotion] = useState(false);
-
-  useEffect(() => {
-    // Check if user prefers reduced motion
-    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
-    setReduceMotion(mediaQuery.matches);
-  }, []);
+  const reduceMotion = usePrefersReducedMotion();
 
   const { leaderboard, profiles } = useLeaderboardData({
     startDate,
@@ -32,7 +27,7 @@ const LeaderboardBannerComponent: FC<Props> = ({
   const users = useMemo(() => {
     return leaderboard?.users ?? [];
   }, [leaderboard?.users]);
-  
+
   const hotdogs = useMemo(() => {
     return leaderboard?.hotdogs ?? [];
   }, [leaderboard?.hotdogs]);

--- a/src/components/utils/Buy.tsx
+++ b/src/components/utils/Buy.tsx
@@ -1,32 +1,33 @@
-import { useContext, useEffect, useState, type FC } from "react";
+import { useContext, type FC } from "react";
 import { darkTheme, lightTheme, BuyWidget } from "thirdweb/react";
 import { client } from "~/providers/Thirdweb";
 import { Portal } from "./Portal";
 import { DEFAULT_CHAIN, HOTDOG_TOKEN, MINIMUM_STAKE } from "~/constants";
 import { toTokens } from "thirdweb";
 import { FarcasterContext } from "~/providers/Farcaster";
+import usePrefersDarkMode from "~/hooks/usePrefersDarkMode";
 
 export const Buy: FC = () => {
   const farcaster = useContext(FarcasterContext);
   const isMiniApp = farcaster?.isMiniApp ?? false;
-  const [userPrefersDarkMode, setUserPrefersDarkMode] = useState<boolean>(false);
-  useEffect(() => {
-    setUserPrefersDarkMode(window.matchMedia('(prefers-color-scheme: dark)').matches);
-  }, []);
+  const userPrefersDarkMode = usePrefersDarkMode();
 
   const handleMiniAppBuy = async () => {
     if (!farcaster?.context) return;
-    return farcaster.swapToken(HOTDOG_TOKEN[DEFAULT_CHAIN.id]! as `0x${string}`, toTokens(MINIMUM_STAKE, 18));
-  }
+    return farcaster.swapToken(
+      HOTDOG_TOKEN[DEFAULT_CHAIN.id]! as `0x${string}`,
+      toTokens(MINIMUM_STAKE, 18),
+    );
+  };
 
   if (isMiniApp) {
     return (
       <button className="btn btn-primary" onClick={handleMiniAppBuy}>
         Buy $HOTDOG
       </button>
-    )
+    );
   }
-  
+
   return (
     <>
       <label htmlFor="buy_modal" className="btn btn-primary">
@@ -35,27 +36,34 @@ export const Buy: FC = () => {
       <Portal>
         <input type="checkbox" id="buy_modal" className="modal-toggle" />
         <div className="modal modal-bottom sm:modal-middle">
-          <div className="modal-box backdrop-blur-sm bg-opacity-50 w-full p-0 m-0 flex items-center justify-center">
+          <div className="modal-box m-0 flex w-full items-center justify-center bg-opacity-50 p-0 backdrop-blur-sm">
             <BuyWidget
               client={client}
               chain={DEFAULT_CHAIN}
               tokenAddress={HOTDOG_TOKEN[DEFAULT_CHAIN.id]! as `0x${string}`}
               amount={toTokens(MINIMUM_STAKE, 18)}
               title="Buy $HOTDOG"
-              theme={userPrefersDarkMode
-                ? darkTheme({
-                    colors: {
-                      borderColor: "transparent",
-                    },
-                  })
-                : lightTheme({
-                    colors: {
-                      borderColor: "transparent",
-                    },
-                  })}
+              theme={
+                userPrefersDarkMode
+                  ? darkTheme({
+                      colors: {
+                        borderColor: "transparent",
+                      },
+                    })
+                  : lightTheme({
+                      colors: {
+                        borderColor: "transparent",
+                      },
+                    })
+              }
             />
             <div className="modal-action">
-              <label htmlFor="buy_modal" className="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
+              <label
+                htmlFor="buy_modal"
+                className="btn btn-circle btn-sm absolute right-2 top-2"
+              >
+                ✕
+              </label>
             </div>
           </div>
         </div>

--- a/src/components/utils/Layout.tsx
+++ b/src/components/utils/Layout.tsx
@@ -1,44 +1,55 @@
-import { type FC, type ReactNode,useEffect, useState } from "react"
+import { type FC, type ReactNode } from "react";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import { BottomNav } from "./BottomNav";
 import { ToastProvider } from "~/providers/Toast";
+import usePrefersDarkMode from "~/hooks/usePrefersDarkMode";
+import useMounted from "~/hooks/useMounted";
 interface LayoutProps {
-  children: ReactNode
+  children: ReactNode;
 }
 
 export const Layout: FC<LayoutProps> = ({ children }) => {
   const router = useRouter();
 
-  const [userPrefersDarkMode, setUserPrefersDarkMode] = useState<boolean>(false);
-  const [mounted, setMounted] = useState(false);
-  
-  useEffect(() => {
-    setMounted(true);
-    setUserPrefersDarkMode(window.matchMedia('(prefers-color-scheme: dark)').matches);
-  }, []);
+  const mounted = useMounted();
+  const userPrefersDarkMode = usePrefersDarkMode();
 
   // Prevent hydration mismatch by not applying dark mode styles until mounted
-  const fromYellow = mounted && userPrefersDarkMode ? "from-yellow-300" : "from-yellow-100";
-  const toYellow = mounted && userPrefersDarkMode ? "to-yellow-800" : "to-yellow-00";
-  const fromPink = mounted && userPrefersDarkMode ? "from-pink-300" : "from-pink-100";
+  const fromYellow =
+    mounted && userPrefersDarkMode ? "from-yellow-300" : "from-yellow-100";
+  const toYellow =
+    mounted && userPrefersDarkMode ? "to-yellow-800" : "to-yellow-00";
+  const fromPink =
+    mounted && userPrefersDarkMode ? "from-pink-300" : "from-pink-100";
   const toPink = mounted && userPrefersDarkMode ? "to-pink-800" : "to-pink-500";
-  const viaPink = mounted && userPrefersDarkMode ? "via-pink-300" : "via-pink-200";
-  const darkModeOpacity = mounted && userPrefersDarkMode ? 'opacity-30' : '';
+  const viaPink =
+    mounted && userPrefersDarkMode ? "via-pink-300" : "via-pink-200";
+  const darkModeOpacity = mounted && userPrefersDarkMode ? "opacity-30" : "";
 
   return (
     <div className="block">
-      <div className={`absolute bg-gradient-to-t ${fromYellow} ${toYellow} rounded-full blur-3xl -top-[75%] -left-[45%] w-full h-full -z-10 ${darkModeOpacity}`} ></div>
-      <div className={`fixed bg-gradient-to-br ${fromYellow} ${viaPink} ${toPink} rounded-full blur-3xl -bottom-0 -right-[90%] w-full h-full -z-10 ${darkModeOpacity}`}></div>
-      <div className={`fixed bg-gradient-to-br ${fromYellow} ${viaPink} ${toPink} rounded-full blur-3xl -bottom-0 -left-[55%] w-1/2 h-full -z-10 ${darkModeOpacity}`}></div>
-      <div className={`fixed bg-gradient-to-tl ${fromYellow} ${viaPink} ${toYellow} rounded-full blur-3xl -bottom-0 -left-[25%] w-1/2 h-full -z-10 ${darkModeOpacity}`}></div>
-      <div className={`fixed bg-gradient-to-bl ${fromPink} ${toPink} rounded-full -top-[-85%] blur-3xl -left-[35%] w-full h-full -z-10 ${darkModeOpacity}`}></div>
-      <div className="overflow-x-hidden max-w-7xl mx-auto min-h-screen pb-24">
-        <div className="w-full justify-between items-center flex mr-4">
+      <div
+        className={`absolute bg-gradient-to-t ${fromYellow} ${toYellow} -left-[45%] -top-[75%] -z-10 h-full w-full rounded-full blur-3xl ${darkModeOpacity}`}
+      ></div>
+      <div
+        className={`fixed bg-gradient-to-br ${fromYellow} ${viaPink} ${toPink} -bottom-0 -right-[90%] -z-10 h-full w-full rounded-full blur-3xl ${darkModeOpacity}`}
+      ></div>
+      <div
+        className={`fixed bg-gradient-to-br ${fromYellow} ${viaPink} ${toPink} -bottom-0 -left-[55%] -z-10 h-full w-1/2 rounded-full blur-3xl ${darkModeOpacity}`}
+      ></div>
+      <div
+        className={`fixed bg-gradient-to-tl ${fromYellow} ${viaPink} ${toYellow} -bottom-0 -left-[25%] -z-10 h-full w-1/2 rounded-full blur-3xl ${darkModeOpacity}`}
+      ></div>
+      <div
+        className={`fixed bg-gradient-to-bl ${fromPink} ${toPink} -left-[35%] -top-[-85%] -z-10 h-full w-full rounded-full blur-3xl ${darkModeOpacity}`}
+      ></div>
+      <div className="mx-auto min-h-screen max-w-7xl overflow-x-hidden pb-24">
+        <div className="mr-4 flex w-full items-center justify-between">
           <div className="flex items-center gap-2">
-            {router.pathname !== '/' && (
-              <Link href="/" className="btn btn-ghost text-neutral ml-4 pt-6">
-                🌭  Log a Dog
+            {router.pathname !== "/" && (
+              <Link href="/" className="btn btn-ghost ml-4 pt-6 text-neutral">
+                🌭 Log a Dog
               </Link>
             )}
           </div>
@@ -48,5 +59,5 @@ export const Layout: FC<LayoutProps> = ({ children }) => {
         <BottomNav />
       </div>
     </div>
-  )
-}
+  );
+};

--- a/src/components/utils/Portal.tsx
+++ b/src/components/utils/Portal.tsx
@@ -1,18 +1,22 @@
-import { type ReactNode,useEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
+import { type ReactNode, useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import useMounted from "~/hooks/useMounted";
 
 interface PortalProps {
-  children: ReactNode
+  children: ReactNode;
 }
 
 export const Portal = (props: PortalProps) => {
   const ref = useRef<Element | null>(null);
-  const [mounted, setMounted] = useState<boolean>(false);
-  
-  useEffect(() => {
-    ref.current = document.querySelector<HTMLElement>("#portal")
-    setMounted(true)
-  }, []);
+  const mounted = useMounted();
 
-  return (mounted && ref.current) ? createPortal(<div>{props.children}</div>, ref.current) : null
-}
+  useEffect(() => {
+    if (mounted) {
+      ref.current = document.querySelector<HTMLElement>("#portal");
+    }
+  }, [mounted]);
+
+  return mounted && ref.current
+    ? createPortal(<div>{props.children}</div>, ref.current)
+    : null;
+};

--- a/src/hooks/useMounted.ts
+++ b/src/hooks/useMounted.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from "react";
+
+const useMounted = (): boolean => {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return mounted;
+};
+
+export default useMounted;

--- a/src/hooks/usePrefersDarkMode.ts
+++ b/src/hooks/usePrefersDarkMode.ts
@@ -1,0 +1,17 @@
+import { useSyncExternalStore } from "react";
+
+const subscribe = (callback: () => void) => {
+  const media = window.matchMedia("(prefers-color-scheme: dark)");
+  media.addEventListener("change", callback);
+  return () => media.removeEventListener("change", callback);
+};
+
+const getSnapshot = () =>
+  window.matchMedia("(prefers-color-scheme: dark)").matches;
+
+const getServerSnapshot = () => false;
+
+const usePrefersDarkMode = (): boolean =>
+  useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+export default usePrefersDarkMode;

--- a/src/hooks/usePrefersReducedMotion.ts
+++ b/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,17 @@
+import { useSyncExternalStore } from "react";
+
+const subscribe = (callback: () => void) => {
+  const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+  media.addEventListener("change", callback);
+  return () => media.removeEventListener("change", callback);
+};
+
+const getSnapshot = () =>
+  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+const getServerSnapshot = () => false;
+
+const usePrefersReducedMotion = (): boolean =>
+  useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+export default usePrefersReducedMotion;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,8 @@
 import Head from "next/head";
 import Link from "next/link";
 // import Link from "next/link";
-import { useState, useEffect } from "react";
+import usePrefersDarkMode from "~/hooks/usePrefersDarkMode";
+import useMounted from "~/hooks/useMounted";
 import { CreateAttestation } from "~/components/Attestation/Create";
 import { ListAttestations } from "~/components/Attestation/List";
 import { LeaderboardBanner } from "~/components/LeaderboardBanner";
@@ -34,15 +35,8 @@ export const getStaticProps = async () => {
 };
 
 export default function Home() {
-  const [userPrefersDarkMode, setUserPrefersDarkMode] = useState<boolean>(false);
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-    setUserPrefersDarkMode(
-      window.matchMedia("(prefers-color-scheme: dark)").matches,
-    );
-  }, []);
+  const mounted = useMounted();
+  const userPrefersDarkMode = usePrefersDarkMode();
 
   const bannerSrc =
     mounted && userPrefersDarkMode


### PR DESCRIPTION
## Summary
- factor out user preference logic into hooks
- use `useMounted` and `usePrefersDarkMode` across pages and components
- create `usePrefersReducedMotion` for banner animation
- refactor Portal to use shared mounted hook

## Testing
- `npx prettier -w ...`
- `NEXTAUTH_SECRET=foo NEXTAUTH_URL=http://localhost:3000 NEXT_PUBLIC_THIRDWEB_CLIENT_ID=foo THIRDWEB_SECRET_KEY=foo SKIP_ENV_VALIDATION=true bun run build`

------
https://chatgpt.com/codex/tasks/task_e_687ba3cab5b0833198696f6d6f850f56