### PR TITLE
Refactor: reduce useEffect hooks

### DIFF
--- a/src/components/Attestation/Create.tsx
+++ b/src/components/Attestation/Create.tsx
@@ -96,7 +96,14 @@ const CreateAttestationComponent: FC<Props> = ({ onAttestationCreated }) => {
   // Query for dog event when we have a transaction hash
   const { data: dogEvent } = api.hotdog.getDogEventByTransactionHash.useQuery(
     { transactionHash: transactionHash! },
-    { enabled: !!transactionHash && isTransactionIdResolved }
+    {
+      enabled: !!transactionHash && isTransactionIdResolved,
+      onSuccess: () => {
+        if (transactionId) {
+          removePendingDog(transactionId);
+        }
+      },
+    }
   );
 
   // Show share dialog when dog event is loaded
@@ -107,12 +114,6 @@ const CreateAttestationComponent: FC<Props> = ({ onAttestationCreated }) => {
     }
   }, [isMiniApp, dogEvent, isTransactionIdResolved]);
 
-  // Remove the optimistic dog once the real data is available
-  useEffect(() => {
-    if (dogEvent && transactionId) {
-      removePendingDog(transactionId);
-    }
-  }, [dogEvent, transactionId, removePendingDog]);
 
   const handleOnResolved = (success: boolean) => {
     if (success && account && transactionId) {

--- a/src/components/Attestation/UserList.tsx
+++ b/src/components/Attestation/UserList.tsx
@@ -35,25 +35,21 @@ export const UserListAttestations: FC<Props> = ({ user, limit }) => {
     enabled: !!DEFAULT_CHAIN.id,
     refetchOnWindowFocus: false,
     refetchOnMount: false,
+    onSettled: () => setIsPaginating(false),
   });
 
 
   useEffect(() => {
-    // Only refetch if account actually changed and we haven't already refetched for this account
     if (account?.address && account.address !== lastAccountRef.current) {
       lastAccountRef.current = account.address;
       void refetchDogData();
     }
+    return () => {
+      if (paginationTimeoutRef.current) {
+        clearTimeout(paginationTimeoutRef.current);
+      }
+    };
   }, [account?.address, refetchDogData]);
-
-  // Handle pagination loading state
-  useEffect(() => {
-    if (isLoadingHotdogs && start > 0) {
-      setIsPaginating(true);
-    } else {
-      setIsPaginating(false);
-    }
-  }, [isLoadingHotdogs, start]);
 
   // Mobile-safe scroll function
   const scrollToTop = () => {
@@ -92,14 +88,6 @@ export const UserListAttestations: FC<Props> = ({ user, limit }) => {
     scrollToTop();
   };
 
-  // Cleanup timeouts on unmount
-  useEffect(() => {
-    return () => {
-      if (paginationTimeoutRef.current) {
-        clearTimeout(paginationTimeoutRef.current);
-      }
-    };
-  }, []);
 
   return (
     <div className="grid md:grid-cols-2 grid-cols-1 gap-4 relative">

--- a/src/components/Notifications/Settings.tsx
+++ b/src/components/Notifications/Settings.tsx
@@ -1,6 +1,6 @@
 import { BellIcon, BellSlashIcon } from "@heroicons/react/24/outline";
 import { useSession } from "next-auth/react";
-import { useCallback, useContext, useMemo, useState, useEffect, type FC } from "react";
+import { useCallback, useContext, useMemo, useState, type FC } from "react";
 import { toast } from "react-toastify";
 import { FarcasterContext } from "~/providers/Farcaster";
 import { api } from "~/utils/api";
@@ -72,14 +72,6 @@ export const NotificationsSettings: FC<Props> = ({ className }) => {
     return farcaster?.context?.client?.added ?? false;
   }, [farcaster?.context?.client?.added]);
 
-  // Update step based on mini app status
-  useEffect(() => {
-    if (hasAddedMiniApp) {
-      setCurrentStep(2);
-    } else {
-      setCurrentStep(1);
-    }
-  }, [hasAddedMiniApp]);
 
   const handleToggle = useCallback(async (checked: boolean) => {
     if (!userAddress || isSessionLoading) {

--- a/src/hooks/useIsOnMobileSafari.ts
+++ b/src/hooks/useIsOnMobileSafari.ts
@@ -1,21 +1,15 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 const useIsOnMobileSafari = () => {
-  const [isMounted, setIsMounted] = useState<boolean>(false);
-  
   const isOnMobileSafari = useMemo(() => {
-    if (!isMounted) return false;
+    if (typeof navigator === 'undefined') return false;
     const ua = navigator.userAgent;
-    const iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);
-    const webkit = !!ua.match(/WebKit/i);
-    const iOSSafari = iOS && webkit && !ua.match(/CriOS/i);
+    const iOS = /iPad|iPhone/i.test(ua);
+    const webkit = /WebKit/i.test(ua);
+    const iOSSafari = iOS && webkit && !/CriOS/i.test(ua);
     return iOSSafari;
-  }, [isMounted]);
-
-  useEffect(() => {
-    setIsMounted(true);
   }, []);
-  
+
   return {
     isOnMobileSafari,
   }

--- a/src/hooks/usePrevious.ts
+++ b/src/hooks/usePrevious.ts
@@ -1,12 +1,13 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function usePrevious(value: any) {
   const ref = useRef();
-  useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    ref.current = value; //assign the value of ref to the argument
-  },[value]); //this code will run when the value of 'value' changes
-  return ref.current; //in the end, return the current ref value.
+  const previous = ref.current;
+  // update the ref with the latest value for next render
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  ref.current = value;
+  return previous;
 }
+
 export default usePrevious;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import Head from "next/head";
 import Link from "next/link";
 // import Link from "next/link";
-import { useState, useEffect } from "react";
+import React from "react";
 import { CreateAttestation } from "~/components/Attestation/Create";
 import { ListAttestations } from "~/components/Attestation/List";
 import { LeaderboardBanner } from "~/components/LeaderboardBanner";
@@ -34,20 +34,6 @@ export const getStaticProps = async () => {
 };
 
 export default function Home() {
-  const [userPrefersDarkMode, setUserPrefersDarkMode] = useState<boolean>(false);
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-    setUserPrefersDarkMode(
-      window.matchMedia("(prefers-color-scheme: dark)").matches,
-    );
-  }, []);
-
-  const bannerSrc =
-    mounted && userPrefersDarkMode
-      ? "/images/banner-dark.png"
-      : "/images/banner.png";
 
   return (
     <>
@@ -65,11 +51,20 @@ export default function Home() {
         <div className="container flex flex-col items-center justify-center gap-4 px-4 pb-8 pt-8">
           <h1 className="flex items-center text-5xl font-extrabold tracking-tight sm:text-[5rem]">
             <Image
-              src={bannerSrc}
+              src="/images/banner.png"
               alt="Log a Dog"
               width={500}
               height={500}
               priority
+              className="dark:hidden"
+            />
+            <Image
+              src="/images/banner-dark.png"
+              alt="Log a Dog"
+              width={500}
+              height={500}
+              priority
+              className="hidden dark:block"
             />
           </h1>
           <div className="-mt-8 flex items-center gap-2">

--- a/src/providers/Farcaster.tsx
+++ b/src/providers/Farcaster.tsx
@@ -110,6 +110,10 @@ export const FarcasterProvider = ({
         const mini = await sdk.isInMiniApp();
         setIsMiniApp(mini);
         await sdk.actions.ready({});
+        if (sdk.wallet && !hasConnectedWallet) {
+          await connectWallet();
+          setHasConnectedWallet(true);
+        }
       } catch (err) {
         console.error("Failed to load SDK", err);
       }
@@ -118,14 +122,7 @@ export const FarcasterProvider = ({
       setIsSDKLoaded(true);
       void load();
     }
-  }, [isSDKLoaded]);
-
-  // Separate effect for wallet connection after context is loaded
-  useEffect(() => {
-    if (context && sdk.wallet && isSDKLoaded && !hasConnectedWallet) {
-      void connectWallet().then(() => setHasConnectedWallet(true));
-    }
-  }, [context, isSDKLoaded, connectWallet, hasConnectedWallet]);
+  }, [isSDKLoaded, connectWallet, hasConnectedWallet]);
 
   const value = useMemo(
     () => ({


### PR DESCRIPTION
## Summary
- simplify `usePrevious` without an effect
- remove state and effect from `useIsOnMobileSafari`
- combine Farcaster provider effects
- switch homepage banner to CSS dark mode images
- streamline attestation list and user list effects
- remove step syncing effect in notification settings
- clean up pending dog removal logic

## Testing
- `bun install`
- `THIRDWEB_SECRET_KEY=test THIRDWEB_CLIENT_ID=test NEXT_PUBLIC_THIRDWEB_CLIENT_ID=test SKIP_ENV_VALIDATION=true bun run build`


------
https://chatgpt.com/codex/tasks/task_e_687b9f9f65c88331a3def62ff33611ea