### PR TITLE
fix: prevent infinite re-renders on homepage

### DIFF
--- a/src/components/Attestation/List.tsx
+++ b/src/components/Attestation/List.tsx
@@ -128,13 +128,13 @@ export const ListAttestations: FC<Props> = ({ limit }) => {
   }, [clearExpiredPending, isClient]);
 
   // Smart deduplication: only filter out optimistic data when real data with same logId exists
-  const realLogIds = new Set(dogData?.hotdogs?.map(h => h.logId) ?? []);
-  const filteredPendingDogs = pendingDogs.filter(pending => {
-    const hasRealData = realLogIds.has(pending.logId);
-    if (hasRealData) {
-    }
-    return !hasRealData;
-  });
+  const filteredPendingDogs = useMemo(() => {
+    const realLogIds = new Set(dogData?.hotdogs?.map(h => h.logId) ?? []);
+    return pendingDogs.filter(pending => {
+      const hasRealData = realLogIds.has(pending.logId);
+      return !hasRealData;
+    });
+  }, [dogData?.hotdogs, pendingDogs]);
 
   const allHotdogs: HotdogItem[] = useMemo(() => {
     return dogData?.hotdogs ? [...filteredPendingDogs, ...dogData.hotdogs] : pendingDogs;


### PR DESCRIPTION
## Summary
- Fixed infinite re-rendering issue on homepage by properly memoizing `filteredPendingDogs` array in `ListAttestations` component
- The array was being recreated on every render, causing dependent `useMemo` hooks to constantly invalidate

## Root Cause
The `filteredPendingDogs` array in `/src/components/Attestation/List.tsx` was not memoized, causing it to be recreated on every render. This triggered the `allHotdogs` useMemo to constantly recreate its array, leading to infinite re-renders.

## Changes
- Wrapped `filteredPendingDogs` logic in `useMemo` with proper dependencies (`dogData?.hotdogs` and `pendingDogs`)
- Removed unnecessary empty log statement in filter function

## Test plan
- [x] Build passes (`npm run build`)
- [x] Linting passes (`npm run lint`) 
- [x] Homepage should no longer experience constant re-renders
- [x] Functionality remains the same - pending dogs still properly filtered and displayed

🤖 Generated with [Claude Code](https://claude.ai/code)