### PR TITLE
Re-enable trading button on mobile

### DIFF
--- a/src/components/Attestation/ZoraCoinTrading.tsx
+++ b/src/components/Attestation/ZoraCoinTrading.tsx
@@ -238,10 +238,6 @@ export const ZoraCoinTrading: FC<Props> = ({ coinAddress: _coinAddress, logId, r
   //   }
   // };
 
-  // Don't render on mobile to prevent performance issues
-  if (isMobile) {
-    return null;
-  }
 
   return (
     <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- remove mobile-only guard to show trade button on all devices

## Testing
- `SKIP_ENV_VALIDATION=true bun run build`

------
https://chatgpt.com/codex/tasks/task_e_687c71634b688331a27467cbdea92fd2