### PR TITLE
Fix advanced options modal scroll

### DIFF
--- a/src/components/Attestation/Create.tsx
+++ b/src/components/Attestation/Create.tsx
@@ -330,7 +330,7 @@ const CreateAttestationComponent: FC<Props> = ({ onAttestationCreated }) => {
         🌭
       </button>
       <dialog id="create_attestation_modal" className="modal">
-        <div className="modal-box overflow-hidden">
+        <div className="modal-box max-h-[90vh] overflow-y-auto">
           <h3 className="font-bold text-2xl mb-4">Log a Dog</h3>
           <div className="flex flex-col gap-2">
             <Upload


### PR DESCRIPTION
## Summary
- enable scrolling in the create attestation modal so advanced settings are accessible

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687ce0701724833188cd142a9ce52dcd