### PR TITLE
Make spam indicator icon red

### DIFF
--- a/src/components/Profile/Badge.tsx
+++ b/src/components/Profile/Badge.tsx
@@ -55,7 +55,7 @@ export const Badge: FC<{
           onClick={() => (document.getElementById(spammerModalId) as HTMLDialogElement)?.showModal()}
           className={`cursor-pointer hover:opacity-80 transition-opacity inline-flex items-center justify-center ${className}`}
         >
-          <ExclamationTriangleIcon className="w-4 h-4 text-warning" />
+          <ExclamationTriangleIcon className="w-4 h-4 text-error" />
         </button>
 
           <dialog id={spammerModalId} className="modal modal-bottom sm:modal-middle">
@@ -67,7 +67,7 @@ export const Badge: FC<{
                 <XMarkIcon className="w-4 h-4" />
               </button>
               <h3 className="font-bold text-lg flex items-center gap-2">
-                <ExclamationTriangleIcon className="w-6 h-6 stroke-2 text-warning" />
+                <ExclamationTriangleIcon className="w-6 h-6 stroke-2 text-error" />
                 Known Spammer
               </h3>
               <div className="py-4 space-y-2">


### PR DESCRIPTION
## Summary
- change color of `ExclamationTriangleIcon` for known spammers to use `text-error`

## Testing
- `npm run lint` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_688563233b14833186a07e0ddd9bf4ff