### PR TITLE
Avoid telegram message when no rewards processed

### DIFF
--- a/src/pages/api/cron/reward-moderators.ts
+++ b/src/pages/api/cron/reward-moderators.ts
@@ -176,12 +176,15 @@ export default async function handler(
     console.log(`Moderator reward process completed: ${results.processed} processed, ${results.skipped} skipped, ${results.errors} errors`);
 
     // Send Telegram notification for cron job completion
-    try {
-      const message = formatCronJobMessage(results.processed, results.skipped);
-      await sendTelegramMessage(message);
-    } catch (telegramError) {
-      console.error('Failed to send Telegram notification:', telegramError);
-      // Don't fail the cron job if Telegram fails
+    // Only notify if some rewards were actually processed
+    if (results.processed > 0) {
+      try {
+        const message = formatCronJobMessage(results.processed, results.skipped);
+        await sendTelegramMessage(message);
+      } catch (telegramError) {
+        console.error('Failed to send Telegram notification:', telegramError);
+        // Don't fail the cron job if Telegram fails
+      }
     }
 
     // Explicitly disconnect from database


### PR DESCRIPTION
## Summary
- skip telegram cron notification when no rewards are handled

## Testing
- `npm test` (fails: Missing script: "test")
- `SKIP_ENV_VALIDATION=1 npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893bd9356b08331be82f2a34f7f2c1e