### PR TITLE
Exclude disqualified users from leaderboards

### DIFF
--- a/src/components/LeaderboardBanner.tsx
+++ b/src/components/LeaderboardBanner.tsx
@@ -86,11 +86,12 @@ const LeaderboardBannerComponent: FC<Props> = ({
                 <div className="text-sm font-medium">
                   {displayName}
                 </div>
-                <Badge 
+                <Badge
                   address={address}
                   fid={profile?.fid}
                   isKnownSpammer={profile?.isKnownSpammer}
                   isReportedForSpam={profile?.isReportedForSpam}
+                  isDisqualified={profile?.isDisqualified}
                 />
                 <div className="flex items-center gap-1">
                   <span className="text-sm font-bold">{hotdogCount}</span>
@@ -166,11 +167,12 @@ const LeaderboardBannerComponent: FC<Props> = ({
                 <div className="text-sm font-medium">
                   {displayName}
                 </div>
-                <Badge 
+                <Badge
                   address={address}
                   fid={profile?.fid}
                   isKnownSpammer={profile?.isKnownSpammer}
                   isReportedForSpam={profile?.isReportedForSpam}
+                  isDisqualified={profile?.isDisqualified}
                 />
                 <div className="flex items-center gap-1">
                   <span className="text-sm font-bold">{hotdogCount}</span>
@@ -216,11 +218,12 @@ const LeaderboardBannerComponent: FC<Props> = ({
                 <div className="text-sm font-medium">
                   {displayName}
                 </div>
-                <Badge 
+                <Badge
                   address={address}
                   fid={profile?.fid}
                   isKnownSpammer={profile?.isKnownSpammer}
                   isReportedForSpam={profile?.isReportedForSpam}
+                  isDisqualified={profile?.isDisqualified}
                 />
                 <div className="flex items-center gap-1">
                   <span className="text-sm font-bold">{hotdogCount}</span>

--- a/src/components/LeaderboardList.tsx
+++ b/src/components/LeaderboardList.tsx
@@ -24,6 +24,7 @@ type ProfileData = {
   fid?: number | null;
   isKnownSpammer?: boolean | null;
   isReportedForSpam?: boolean | null;
+  isDisqualified?: boolean | null;
 };
 
 const LeaderboardListComponent: FC<LeaderboardListProps> = ({

--- a/src/components/Profile/Badge.tsx
+++ b/src/components/Profile/Badge.tsx
@@ -1,15 +1,17 @@
-import { CheckBadgeIcon, ExclamationTriangleIcon, XMarkIcon, FlagIcon } from "@heroicons/react/24/outline";
+import { CheckBadgeIcon, ExclamationTriangleIcon, XMarkIcon, FlagIcon, NoSymbolIcon } from "@heroicons/react/24/outline";
 import { type FC, useMemo, useState } from "react";
 
-export const Badge: FC<{ 
-  address: string; 
-  isKnownSpammer?: boolean | null; 
-  isReportedForSpam?: boolean | null; 
-  fid?: number | null; 
+export const Badge: FC<{
+  address: string;
+  isKnownSpammer?: boolean | null;
+  isReportedForSpam?: boolean | null;
+  isDisqualified?: boolean | null;
+  fid?: number | null;
   className?: string;
-}> = ({ address, isKnownSpammer, isReportedForSpam, fid, className }) => {
+}> = ({ address, isKnownSpammer, isReportedForSpam, isDisqualified, fid, className }) => {
   const spammerModalId = useMemo(() => `spammer-badge-${address.toLowerCase()}-${Math.random().toString(36).substring(2, 15)}`, [address]);
   const verifiedModalId = useMemo(() => `verified-badge-${address.toLowerCase()}-${Math.random().toString(36).substring(2, 15)}`, [address]);
+  const disqualifiedModalId = useMemo(() => `disqualified-badge-${address.toLowerCase()}-${Math.random().toString(36).substring(2, 15)}`, [address]);
   
   const [isReporting, setIsReporting] = useState(false);
   const [reportStatus, setReportStatus] = useState<'idle' | 'success' | 'error'>('idle');
@@ -43,15 +45,54 @@ export const Badge: FC<{
     } catch (error) {
       console.error('Error reporting user:', error);
       setReportStatus('error');
-    } finally {
-      setIsReporting(false);
-    }
-  };
+  } finally {
+    setIsReporting(false);
+  }
+};
+
+  if (isDisqualified) {
+    return (
+      <>
+        <button
+          onClick={() => (document.getElementById(disqualifiedModalId) as HTMLDialogElement)?.showModal()}
+          className={`cursor-pointer hover:opacity-80 transition-opacity inline-flex items-center justify-center ${className}`}
+        >
+          <NoSymbolIcon className="w-4 h-4 text-error" />
+        </button>
+
+          <dialog id={disqualifiedModalId} className="modal modal-bottom sm:modal-middle">
+            <div className="modal-box relative bg-base-100 bg-opacity-90 backdrop-blur-lg">
+              <button
+                onClick={() => (document.getElementById(disqualifiedModalId) as HTMLDialogElement)?.close()}
+                className="btn btn-ghost btn-circle btn-xs absolute top-4 right-4"
+              >
+                <XMarkIcon className="w-4 h-4" />
+              </button>
+              <h3 className="font-bold text-lg flex items-center gap-2">
+                <NoSymbolIcon className="w-6 h-6 stroke-2 text-error" />
+                Disqualified
+              </h3>
+              <div className="py-4 space-y-2">
+                <p>This user has been disqualified from the contest.</p>
+              </div>
+              <div className="modal-action">
+                <button
+                  onClick={() => (document.getElementById(disqualifiedModalId) as HTMLDialogElement)?.close()}
+                  className="btn"
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+          </dialog>
+      </>
+    );
+  }
 
   if (isKnownSpammer) {
     return (
       <>
-        <button 
+        <button
           onClick={() => (document.getElementById(spammerModalId) as HTMLDialogElement)?.showModal()}
           className={`cursor-pointer hover:opacity-80 transition-opacity inline-flex items-center justify-center ${className}`}
         >

--- a/src/components/Profile/Name.tsx
+++ b/src/components/Profile/Name.tsx
@@ -42,7 +42,7 @@ const NameComponent: FC<{ address: string; noLink?: boolean }> = ({ address, noL
     return (
       <div className="flex items-center gap-1">
         <span>{`${address.slice(0, 6)}...${address.slice(-4)}`}</span>
-        <Badge className="z-10" isKnownSpammer={userData?.isKnownSpammer ?? false} isReportedForSpam={userData?.isReportedForSpam ?? false} fid={userData?.fid ?? undefined} address={address} />
+        <Badge className="z-10" isKnownSpammer={userData?.isKnownSpammer ?? false} isReportedForSpam={userData?.isReportedForSpam ?? false} isDisqualified={userData?.isDisqualified ?? false} fid={userData?.fid ?? undefined} address={address} />
       </div>
     )
   }
@@ -51,7 +51,7 @@ const NameComponent: FC<{ address: string; noLink?: boolean }> = ({ address, noL
     return (
       <div className="flex items-center gap-1">
         <span>Unknown</span>
-        <Badge className="z-10" isKnownSpammer={userData?.isKnownSpammer ?? false} isReportedForSpam={userData?.isReportedForSpam ?? false} fid={userData?.fid ?? undefined} address={address} />
+        <Badge className="z-10" isKnownSpammer={userData?.isKnownSpammer ?? false} isReportedForSpam={userData?.isReportedForSpam ?? false} isDisqualified={userData?.isDisqualified ?? false} fid={userData?.fid ?? undefined} address={address} />
       </div>
     );
   }
@@ -59,7 +59,7 @@ const NameComponent: FC<{ address: string; noLink?: boolean }> = ({ address, noL
   const content = (
     <div className="flex items-center gap-1">
       <span>{profile.username}</span>
-      <Badge className="z-20 relative" isKnownSpammer={userData?.isKnownSpammer ?? false} isReportedForSpam={userData?.isReportedForSpam ?? false} fid={userData?.fid ?? undefined} address={address} />
+      <Badge className="z-20 relative" isKnownSpammer={userData?.isKnownSpammer ?? false} isReportedForSpam={userData?.isReportedForSpam ?? false} isDisqualified={userData?.isDisqualified ?? false} fid={userData?.fid ?? undefined} address={address} />
     </div>
   );
 
@@ -79,7 +79,7 @@ const NameComponent: FC<{ address: string; noLink?: boolean }> = ({ address, noL
       >
         {profile.username}
       </Link>
-      <Badge className="z-20 relative" isKnownSpammer={userData?.isKnownSpammer ?? false} isReportedForSpam={userData?.isReportedForSpam ?? false} fid={userData?.fid ?? undefined} address={address} />
+      <Badge className="z-20 relative" isKnownSpammer={userData?.isKnownSpammer ?? false} isReportedForSpam={userData?.isReportedForSpam ?? false} isDisqualified={userData?.isDisqualified ?? false} fid={userData?.fid ?? undefined} address={address} />
     </div>
   );
 };

--- a/src/components/utils/HotdogCard.tsx
+++ b/src/components/utils/HotdogCard.tsx
@@ -82,6 +82,7 @@ type HotdogData = {
     fid?: number | null;
     isKnownSpammer?: boolean | null;
     isReportedForSpam?: boolean | null;
+    isDisqualified?: boolean | null;
   } | null;
   loggerProfile?: {
     name?: string | null;
@@ -90,6 +91,7 @@ type HotdogData = {
     fid?: number | null;
     isKnownSpammer?: boolean | null;
     isReportedForSpam?: boolean | null;
+    isDisqualified?: boolean | null;
   } | null;
 };
 
@@ -222,11 +224,12 @@ export const HotdogCard: FC<Props> = ({
                 <Avatar address={hotdog.eater} fallbackSize={24} />
                 <span className="text-sm font-medium">{displayName}</span>
               </Link>              
-              <Badge 
+              <Badge
                 address={hotdog.eater}
                 fid={hotdog.eaterProfile?.fid}
                 isKnownSpammer={hotdog.eaterProfile?.isKnownSpammer}
                 isReportedForSpam={hotdog.eaterProfile?.isReportedForSpam}
+                isDisqualified={hotdog.eaterProfile?.isDisqualified}
               />
             </div>
             <div className="flex flex-col">
@@ -238,11 +241,12 @@ export const HotdogCard: FC<Props> = ({
                   <span>via</span>
                   <Avatar address={hotdog.logger} size="16px" />
                   <span>{loggerDisplayName}</span>
-                  <Badge 
+                  <Badge
                     address={hotdog.logger}
                     fid={hotdog.loggerProfile?.fid}
                     isKnownSpammer={hotdog.loggerProfile?.isKnownSpammer}
                     isReportedForSpam={hotdog.loggerProfile?.isReportedForSpam}
+                    isDisqualified={hotdog.loggerProfile?.isDisqualified}
                   />
                 </div>
               )}

--- a/src/server/api/dog-events.ts
+++ b/src/server/api/dog-events.ts
@@ -140,15 +140,16 @@ export async function getDogEventLeaderboard(options?: {
       image: true,
       isKnownSpammer: true,
       isReportedForSpam: true,
+      isDisqualified: true,
     },
   });
 
   // Create a map of address to user data and FID
   const addressToFid = new Map<string, number>();
-  const addressToUser = new Map<string, { username?: string | null; name?: string | null; image?: string | null; fid?: number | null; isKnownSpammer?: boolean | null; isReportedForSpam?: boolean | null }>();
+  const addressToUser = new Map<string, { username?: string | null; name?: string | null; image?: string | null; fid?: number | null; isKnownSpammer?: boolean | null; isReportedForSpam?: boolean | null; isDisqualified?: boolean | null }>();
   const fidToAddresses = new Map<number, Set<string>>();
   
-  users.forEach((user: { address: string | null; fid: number | null; username?: string | null; name?: string | null; image?: string | null; isKnownSpammer?: boolean | null; isReportedForSpam?: boolean | null }) => {
+  users.forEach((user: { address: string | null; fid: number | null; username?: string | null; name?: string | null; image?: string | null; isKnownSpammer?: boolean | null; isReportedForSpam?: boolean | null; isDisqualified?: boolean | null }) => {
     if (user.address) {
       const addressLower = user.address.toLowerCase();
       addressToUser.set(addressLower, {
@@ -158,6 +159,7 @@ export async function getDogEventLeaderboard(options?: {
         fid: user.fid,
         isKnownSpammer: user.isKnownSpammer,
         isReportedForSpam: user.isReportedForSpam,
+        isDisqualified: user.isDisqualified,
       });
       
       if (user.fid) {
@@ -171,12 +173,16 @@ export async function getDogEventLeaderboard(options?: {
   });
 
   // Group events by FID (or address if no FID)
-  const groupedCounts = new Map<string, { count: number; addresses: string[]; fid?: number; userData?: { username?: string | null; name?: string | null; image?: string | null; fid?: number | null; isKnownSpammer?: boolean | null; isReportedForSpam?: boolean | null } }>();
+  const groupedCounts = new Map<string, { count: number; addresses: string[]; fid?: number; userData?: { username?: string | null; name?: string | null; image?: string | null; fid?: number | null; isKnownSpammer?: boolean | null; isReportedForSpam?: boolean | null; isDisqualified?: boolean | null } }>();
 
   dogEvents.forEach((event: { eater: string }) => {
     const eaterLower = event.eater.toLowerCase();
     const fid = addressToFid.get(eaterLower);
     const userData = addressToUser.get(eaterLower);
+
+    if (userData?.isDisqualified) {
+      return;
+    }
     
     if (fid) {
       // Group by FID
@@ -213,7 +219,9 @@ export async function getDogEventLeaderboard(options?: {
       image: data.userData?.image,
       isKnownSpammer: data.userData?.isKnownSpammer,
       isReportedForSpam: data.userData?.isReportedForSpam,
+      isDisqualified: data.userData?.isDisqualified,
     }))
+    .filter(l => !l.isDisqualified)
     .sort((a, b) => b.count - a.count);
 
   // Apply pagination

--- a/src/server/api/routers/hotdog.ts
+++ b/src/server/api/routers/hotdog.ts
@@ -129,6 +129,7 @@ interface ProcessedHotdog {
     fid?: number | null;
     isKnownSpammer?: boolean | null;
     isReportedForSpam?: boolean | null;
+    isDisqualified?: boolean | null;
   } | null;
   loggerProfile?: {
     name?: string | null;
@@ -137,6 +138,7 @@ interface ProcessedHotdog {
     fid?: number | null;
     isKnownSpammer?: boolean | null;
     isReportedForSpam?: boolean | null;
+    isDisqualified?: boolean | null;
   } | null;
 }
 
@@ -525,9 +527,10 @@ export const hotdogRouter = createTRPCRouter({
             fid: true,
             isKnownSpammer: true,
             isReportedForSpam: true,
+            isDisqualified: true,
           },
         })
-      ]); 
+      ]);
 
       // Create maps for the fetched data
       const metadataMap = new Map(
@@ -544,6 +547,7 @@ export const hotdogRouter = createTRPCRouter({
             fid: profile.fid,
             isKnownSpammer: profile.isKnownSpammer,
             isReportedForSpam: profile.isReportedForSpam,
+            isDisqualified: profile.isDisqualified,
           }
         ])
       );
@@ -706,6 +710,7 @@ export const hotdogRouter = createTRPCRouter({
             fid: true,
             isKnownSpammer: true,
             isReportedForSpam: true,
+            isDisqualified: true,
           },
         })
       ]);
@@ -725,6 +730,7 @@ export const hotdogRouter = createTRPCRouter({
             fid: profile.fid,
             isKnownSpammer: profile.isKnownSpammer,
             isReportedForSpam: profile.isReportedForSpam,
+            isDisqualified: profile.isDisqualified,
           }
         ])
       );
@@ -867,6 +873,7 @@ export const hotdogRouter = createTRPCRouter({
             fid: true,
             isKnownSpammer: true,
             isReportedForSpam: true,
+            isDisqualified: true,
           },
         })
       ]);
@@ -882,6 +889,7 @@ export const hotdogRouter = createTRPCRouter({
             fid: profile.fid,
             isKnownSpammer: profile.isKnownSpammer,
             isReportedForSpam: profile.isReportedForSpam,
+            isDisqualified: profile.isDisqualified,
           }
         ])
       );
@@ -963,17 +971,18 @@ export const hotdogRouter = createTRPCRouter({
       const cacheKey = `leaderboard:${chainId}:${startDate ?? 'all'}:${endDate ?? 'all'}`;
 
       // Try to get cached data first
-      const cachedData = await getCachedData<{ 
-        users: string[], 
+      const cachedData = await getCachedData<{
+        users: string[],
         hotdogs: string[],
         profiles: Array<{
           address: string;
           name?: string | null;
-          username?: string | null; 
+          username?: string | null;
           image?: string | null;
           fid?: number | null;
           isKnownSpammer?: boolean | null;
           isReportedForSpam?: boolean | null;
+          isDisqualified?: boolean | null;
         }>
       }>(cacheKey);
 
@@ -1002,6 +1011,7 @@ export const hotdogRouter = createTRPCRouter({
             fid: l.fid,
             isKnownSpammer: l.isKnownSpammer,
             isReportedForSpam: l.isReportedForSpam,
+            isDisqualified: l.isDisqualified,
           })),
         };
 

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -16,6 +16,7 @@ export const userRouter = createTRPCRouter({
           fid: true,
           isKnownSpammer: true,
           isReportedForSpam: true,
+          isDisqualified: true,
           username: true,
           image: true,
           name: true,


### PR DESCRIPTION
## Summary
- filter out disqualified users when building leaderboards
- add disqualified state to user badges and propagate through UI

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d3e2bca88331918742bed9fcf5cc