### PR TITLE
Embed Season 2 award ceremony on homepage

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -75,6 +75,18 @@ export default function Home() {
               wtf?
             </Link>
           </div>
+          <div className="w-full max-w-xl">
+            <p className="text-center text-lg font-bold">Season 2 is over! Watch the award ceremony:</p>
+            <div className="mt-2 aspect-video">
+              <iframe
+                className="h-full w-full rounded-lg"
+                src="https://www.youtube.com/embed/U1RklCM-h2g"
+                title="Season 2 Award Ceremony"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+              />
+            </div>
+          </div>
           <CreateAttestation />
           <div role="tablist" className="tabs tabs-boxed">
             {tabs.map((tab) => (


### PR DESCRIPTION
## Summary
- add YouTube embed for Season 2 award ceremony above Log a Dog button
- note that Season 2 has ended

## Testing
- `SKIP_ENV_VALIDATION=true bun run lint`
- `THIRDWEB_SECRET_KEY=placeholder NEXT_PUBLIC_THIRDWEB_CLIENT_ID=placeholder SKIP_ENV_VALIDATION=true bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd9d54c1a4833186c40574231171fa