### PR TITLE
fix(upload): surface upload errors instead of silently closing modal

### DIFF
--- a/src/components/Attestation/Create.tsx
+++ b/src/components/Attestation/Create.tsx
@@ -348,9 +348,12 @@ const CreateAttestationComponent: FC<Props> = ({ onAttestationCreated }) => {
                 setImgUri(uris[0]);
               }}
               initialUrls={memoInitialUpload}
-              onUploadError={() => {
-                // close the modal
-                (document.getElementById('create_attestation_modal') as HTMLDialogElement).close();
+              onUploadError={(error) => {
+                // Keep the modal open so the inline error from <Upload> stays
+                // visible. Previously this closed the modal, which (combined
+                // with the dialog top-layer hiding toasts) made uploads fail
+                // silently with no message.
+                console.error("Upload failed:", error);
               }}
               label={DEFAULT_UPLOAD_PHRASE}
             />

--- a/src/components/utils/Upload.tsx
+++ b/src/components/utils/Upload.tsx
@@ -39,6 +39,7 @@ export const Upload: FC<UploadProps> = ({
 }) => {
   const [urls, setUrls] = useState<string[]>([]);
   const [dropzoneLabel, setDropzoneLabel] = useState<string>(label ?? DEFAULT_UPLOAD_PHRASE);
+  const [uploadError, setUploadError] = useState<string | null>(null);
   const safetyCheck = api.hotdog.checkForSafety.useMutation();
 
   // Prevent re-renders when parent passes a new array reference
@@ -128,16 +129,29 @@ export const Upload: FC<UploadProps> = ({
 
   const onDrop = useCallback(async (acceptedFiles: File[]) => {
     setUrls([]);
+    setUploadError(null);
     setDropzoneLabel("🖼️ Preparing upload...");
 
-    const resizedFilesPromises = acceptedFiles.map(async (file) => {
-      return await resizeImageFile(file);
-    });
-
-    const resizedFiles = await Promise.all(resizedFilesPromises);
+    // Resize / HEIC-convert. This was previously unguarded, so a conversion
+    // failure became an unhandled rejection with no user-visible message.
+    let resizedFiles: File[];
+    try {
+      resizedFiles = await Promise.all(
+        acceptedFiles.map((file) => resizeImageFile(file)),
+      );
+    } catch (e) {
+      const err = e as Error;
+      console.error("Error preparing image:", err);
+      toast.error("Couldn't process that image. Try a JPG or PNG.");
+      setUploadError(`Couldn't process that image: ${err.message}`);
+      onUploadError?.(err);
+      setDropzoneLabel(label ?? DEFAULT_UPLOAD_PHRASE);
+      return;
+    }
 
     if (resizedFiles.length === 0) {
       toast.error("No files to upload");
+      setUploadError("No files to upload");
       onUploadError?.(new Error("No files to upload"));
       setDropzoneLabel(label ?? DEFAULT_UPLOAD_PHRASE);
       return;
@@ -149,14 +163,18 @@ export const Upload: FC<UploadProps> = ({
       const isSafe = await conductImageSafetyCheck(resizedFiles[0]!);
       if (!isSafe) {
         toast.error("Image is not safe to upload");
+        setUploadError("That image didn't pass the safety check.");
         onUploadError?.(new Error("Image is not safe to upload"));
         setDropzoneLabel(label ?? DEFAULT_UPLOAD_PHRASE);
         return;
       }
       setDropzoneLabel("✅ Image passed safety check!");
     } catch (e) {
+      const err = e as Error;
+      console.error("Error checking image safety:", err);
       toast.error("Error checking image safety");
-      onUploadError?.(e as Error);
+      setUploadError(`Safety check failed: ${err.message}`);
+      onUploadError?.(err);
       setDropzoneLabel(label ?? DEFAULT_UPLOAD_PHRASE);
       return;
     }
@@ -186,8 +204,11 @@ export const Upload: FC<UploadProps> = ({
       setUrls(resolvedUrls);
       onUpload?.({ resolvedUrls, uris: typeof uris === 'string' ? [uris] : uris });
     } catch (e) {
+      const err = e as Error;
+      console.error("Error uploading file:", err);
       toast("Error uploading file", { type: "error" });
-      onUploadError?.(e as Error);
+      setUploadError(`Upload failed: ${err.message}`);
+      onUploadError?.(err);
     } finally {
       setDropzoneLabel(label ?? DEFAULT_UPLOAD_PHRASE);
     }
@@ -227,7 +248,12 @@ export const Upload: FC<UploadProps> = ({
             />
           </div>
         ) : (
-          <p>{dropzoneLabel}</p>
+          <div className="flex flex-col items-center gap-1 px-4 text-center">
+            <p>{dropzoneLabel}</p>
+            {uploadError && (
+              <p className="text-error text-xs">{uploadError}</p>
+            )}
+          </div>
         )
       }
     </div>


### PR DESCRIPTION
## Problem
Dropping an image into the **Log a Dog** modal could make it vanish with no message, so it was impossible to tell why an upload failed.

## Root cause
Two compounding issues in the upload flow:

1. **`Create.tsx` closed the modal on any upload error.** The `<dialog>` is opened with `showModal()`, which renders in the browser's **top layer** — above the react-toastify container. So the `toast.error(...)` fired during a failed upload was hidden behind the dialog, and then `onUploadError` closed the dialog. Net effect: modal disappears, no visible message.
2. **`Upload.tsx`'s resize/HEIC-convert step was unguarded.** A conversion failure became an unhandled promise rejection — no toast, no `onUploadError`.

## Fix
- **`Create.tsx`** — `onUploadError` no longer closes the modal; it logs the error and keeps the modal open so the failure stays visible.
- **`Upload.tsx`** —
  - Wrapped the resize/HEIC step in try/catch.
  - Added an inline `uploadError` state rendered in red inside the dropzone, so the failing step is visible **inside the modal** regardless of toast layering.
  - Included `err.message` in safety-check / upload failure messages and logged them to console.

## Note
This makes upload failures **visible and debuggable** — it does not change *why* an upload might fail (e.g. Google Vision safety check or thirdweb storage). Use the preview to drop an image and read the inline red text to pin the actual failing step.

## Test on preview
1. Open the Log a Dog modal, drop an image.
2. On failure: modal stays open and shows the exact error inline (instead of silently closing).
3. On success: image previews and you can proceed to log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)