### PR TITLE
Candy Pop: reconcile the UI palette with the candy background

### DIFF
--- a/docs/REDESIGN.md
+++ b/docs/REDESIGN.md
@@ -437,3 +437,49 @@ import { motion, AnimatePresence } from "motion/react";
   <span className="font-display text-2xl tabular-nums">{hotdogCount} 🌭</span>
 </motion.div>
 ```
+
+---
+
+## 11. "Candy Pop" palette evolution
+
+> Status: **Implemented.** An evolution of the Condiment System (§3), not a replacement.
+
+The original Condiment System dressed the whole UI in warm ballpark tones (cream "bun"
+base, char text/dark-mode). But the app's actual background art (`app-bg`) is a **candy-pop /
+Memphis** aesthetic — soft pink/purple radial gradients, floating translucent bubbles,
+confetti squiggles. The chrome and the backdrop were telling two different stories. Candy
+Pop reconciles them.
+
+**Principle:** condiments stay *semantic*; the neutral/base layer goes *candy*.
+- **Keep** mustard = primary CTA, ketchup = live / rank #1, relish = VALID DOG, sus-red =
+  SUS. These carry meaning in `VoteBar`/leaderboard and must not change.
+- **Shift** `base-100/200/300`, `neutral`, and `base-content` from cream/char to the candy
+  palette: soft pink-cream in light, deep indigo-purple in dark. `info` → periwinkle.
+
+**Light/dark = a real pair.** The pink background (`background.png` /
+`background-dekstop.png`) is light mode; the purple twin is dark mode, wired into `app-bg`
+under `prefers-color-scheme: dark`. Dark mode is now a purple *party*, not a brown
+afterthought. The dark backdrop ships with a CSS radial-gradient fallback so it looks right
+before the art exists — drop `background-dark.png` + `background-dark-desktop.png` into
+`public/images/` to layer the floating bubbles/confetti on top.
+
+| Token | Light (logadog) | Dark (logadog-night) | Role |
+|---|---|---|---|
+| `base-100` | `#FFF1F6` soft pink-cream | `#1A1140` deep indigo-purple | App background |
+| `base-200` | `#FBE0EC` candy pink | `#271858` purple | Cards (via `glass-card`) |
+| `base-content` | `#2B1F3B` deep plum | `#F3E9FF` soft lavender | Ink |
+| `neutral` | `#2B1F3B` plum | `#3A2A6B` purple | Dark surfaces |
+| `info` | `#9B7BE0` periwinkle | `#A78BFA` periwinkle | Quiet metadata |
+| `primary`/`secondary`/`accent`/`error` | unchanged condiments | unchanged neon condiments | Semantic |
+
+**Glass surface.** `glass-card` traded the hard black border for a **1px white glass rim +
+soft colored shadow** and a lighter `blur(28px)`, so the candy gradient and bubbles
+*refract through* the frosted card — the single biggest visual lift, and it only works
+because the background now has color to refract. The per-card `border-4 border-[#1a1a1a]/5`
+overrides in `HotdogCard.tsx` / `List.tsx` were removed so the rim shows.
+
+**Other touches:** feed gap `4 → 6` (gradient peeks between cards); the raised center Log
+button gets a condiment-gradient glow ring (`BottomNav.tsx`).
+
+> Scope: web app (`src/`) only. The separate React Native app under `mobile/` still uses the
+> original cream/char tokens and was intentionally left untouched.

--- a/src/components/Attestation/List.tsx
+++ b/src/components/Attestation/List.tsx
@@ -253,9 +253,9 @@ export const ListAttestations: FC<Props> = ({ limit }) => {
     return (
       <>
         <div id="top-of-list" className="invisible" />
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-6">
           {Array.from({ length: limitOrDefault }).map((_, index) => (
-            <div className="card glass-card overflow-hidden rounded-3xl border-4 border-[#1a1a1a]/5 p-4" key={index}>
+            <div className="card glass-card overflow-hidden rounded-3xl p-4" key={index}>
        
               <div className="flex items-center gap-2">
                 <div className="grill-skeleton h-10 w-10 animate-grill-shimmer rounded-full" />
@@ -316,7 +316,7 @@ export const ListAttestations: FC<Props> = ({ limit }) => {
     <>
       <BackToTopButton />
       <div id="top-of-list" className="invisible" />
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-6">
       <div className="flex justify-end">
         <button
           className="btn btn-ghost btn-sm gap-2"

--- a/src/components/utils/BottomNav.tsx
+++ b/src/components/utils/BottomNav.tsx
@@ -57,25 +57,32 @@ export const BottomNav: FC = () => {
             onClick={() => void router.push("/leaderboard")}
           />
 
-          {/* Raised, ceremonial center Log action. */}
+          {/* Raised, ceremonial center Log action — the center of the party. */}
           <div className="flex justify-center">
-            <motion.button
-              onClick={openLogModal}
-              aria-label="Log a dog"
-              whileTap={{ scale: 0.9 }}
-              whileHover={{ scale: 1.05 }}
-              transition={{ type: "spring", stiffness: 400, damping: 12 }}
-              className="-mt-8 h-16 w-16 overflow-hidden rounded-full border-4 border-base-100 shadow-dog-lg"
-            >
-              <Image
-                src="/images/hotdog-icon.png"
-                alt=""
-                width={64}
-                height={64}
-                className="h-full w-full object-cover"
-                priority
+            <div className="relative isolate -mt-8">
+              {/* Soft candy glow ring behind the button. */}
+              <span
+                aria-hidden
+                className="pointer-events-none absolute inset-0 -z-10 scale-[1.35] rounded-full bg-gradient-to-tr from-secondary via-primary to-accent opacity-70 blur-md"
               />
-            </motion.button>
+              <motion.button
+                onClick={openLogModal}
+                aria-label="Log a dog"
+                whileTap={{ scale: 0.9 }}
+                whileHover={{ scale: 1.05 }}
+                transition={{ type: "spring", stiffness: 400, damping: 12 }}
+                className="h-16 w-16 overflow-hidden rounded-full border-4 border-base-100 shadow-dog-lg"
+              >
+                <Image
+                  src="/images/hotdog-icon.png"
+                  alt=""
+                  width={64}
+                  height={64}
+                  className="h-full w-full object-cover"
+                  priority
+                />
+              </motion.button>
+            </div>
           </div>
 
           <NavButton

--- a/src/components/utils/HotdogCard.tsx
+++ b/src/components/utils/HotdogCard.tsx
@@ -209,7 +209,7 @@ const HotdogCardComponent: FC<Props> = ({
       initial={{ y: -16, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
       transition={{ type: "spring", stiffness: 260, damping: 24 }}
-      className="card glass-card overflow-hidden rounded-3xl border-4 border-[#1a1a1a]/5"
+      className="card glass-card overflow-hidden rounded-3xl"
     >
       <div className="flex flex-col gap-3 p-4">
         {/* Identity row */}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -24,7 +24,8 @@
 }
 
 @layer components {
-  /* Branded backdrop — mobile portrait frame; desktop landscape frame at lg+. */
+  /* Branded backdrop — "Candy Pop": pink candy gradient in light, purple party
+     in dark. Mobile portrait frame; desktop landscape frame at lg+. */
   .app-bg {
     background-color: hsl(var(--b1));
     background-image: url("/images/background.png");
@@ -41,17 +42,55 @@
     }
   }
 
-  /* Frosted liquid-glass surface with a thick black border for clear contrast. */
+  /* Dark mode = the purple party twin. The PNG layer (drop in
+     background-dark.png / background-dark-desktop.png to get the floating
+     bubbles + confetti) sits over a CSS radial-gradient fallback, so dark mode
+     looks good immediately even before the art is added. */
+  @media (prefers-color-scheme: dark) {
+    .app-bg {
+      background-image:
+        url("/images/background-dark.png"),
+        radial-gradient(125% 80% at 82% 8%, rgba(196, 86, 214, 0.45) 0%, rgba(120, 60, 180, 0) 46%),
+        radial-gradient(120% 100% at 50% 48%, rgba(124, 84, 214, 0.32) 0%, rgba(26, 17, 64, 0) 60%),
+        linear-gradient(160deg, #241252 0%, #1a1140 56%, #160d36 100%);
+    }
+
+    @media (min-width: 1024px) {
+      .app-bg {
+        background-image:
+          url("/images/background-dark-desktop.png"),
+          radial-gradient(110% 110% at 85% 0%, rgba(196, 86, 214, 0.42) 0%, rgba(120, 60, 180, 0) 48%),
+          radial-gradient(120% 120% at 50% 50%, rgba(124, 84, 214, 0.30) 0%, rgba(26, 17, 64, 0) 62%),
+          linear-gradient(150deg, #241252 0%, #1a1140 56%, #160d36 100%);
+      }
+    }
+  }
+
+  /* Frosted liquid-glass surface. A 1px white glass rim + soft colored shadow
+     (instead of a hard black border) lets the candy gradient and bubbles refract
+     through the card. */
   .glass-card {
     background: linear-gradient(
       145deg,
-      hsl(var(--b2) / 0.72) 0%,
-      hsl(var(--b2) / 0.45) 55%,
-      hsl(var(--b1) / 0.35) 100%
+      hsl(var(--b1) / 0.55) 0%,
+      hsl(var(--b2) / 0.38) 55%,
+      hsl(var(--b1) / 0.28) 100%
     );
-    backdrop-filter: blur(50px) saturate(1.5);
-    -webkit-backdrop-filter: blur(50px) saturate(1.5);
-    border: 4px solid #1a1a1a;
+    backdrop-filter: blur(28px) saturate(1.7);
+    -webkit-backdrop-filter: blur(28px) saturate(1.7);
+    border: 1px solid hsl(0 0% 100% / 0.55);
+    box-shadow:
+      0 10px 36px -8px rgba(120, 70, 160, 0.28),
+      inset 0 1px 0 0 hsl(0 0% 100% / 0.4);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .glass-card {
+      border-color: hsl(0 0% 100% / 0.14);
+      box-shadow:
+        0 10px 36px -8px rgba(0, 0, 0, 0.55),
+        inset 0 1px 0 0 hsl(0 0% 100% / 0.12);
+    }
   }
 
   /* Grill-mark shimmer sweep for skeleton loaders. */

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -34,20 +34,24 @@ export default {
     darkTheme: "logadog-night",
     themes: [
       {
+        // "Candy Pop" light — condiments kept as *semantic* accents (CTA / live /
+        // valid / sus), but the neutral + base layer is pulled from the pink
+        // candy-pop background so the frosted cards refract the gradient behind
+        // them instead of sitting on flat cream. See docs/REDESIGN.md §11.
         logadog: {
           primary: "#F5C518", // mustard — brand / primary CTAs
-          "primary-content": "#1E1A17",
+          "primary-content": "#2B1F3B",
           secondary: "#E23B2E", // ketchup — energy, rank #1, live
-          "secondary-content": "#FFF8EC",
+          "secondary-content": "#FFF1F6",
           accent: "#5BA84A", // relish — VALID DOG, streaks
-          "accent-content": "#FFF8EC",
-          neutral: "#1E1A17", // char — text, grill marks
-          "neutral-content": "#FFF8EC",
-          "base-100": "#FFF8EC", // bun — warm cream app background
-          "base-200": "#F4E7CE", // toasted bun — cards
-          "base-300": "#E8D5AE",
-          "base-content": "#1E1A17",
-          info: "#7FB7D9", // sky picnic — quiet metadata
+          "accent-content": "#FFF1F6",
+          neutral: "#2B1F3B", // deep plum — text, dark surfaces
+          "neutral-content": "#FFF1F6",
+          "base-100": "#FFF1F6", // soft pink-cream app background
+          "base-200": "#FBE0EC", // candy pink — cards
+          "base-300": "#F6CCE0",
+          "base-content": "#2B1F3B", // deep plum ink (matches navy confetti dots)
+          info: "#9B7BE0", // periwinkle — quiet metadata
           success: "#5BA84A",
           warning: "#F5C518",
           error: "#D7263D", // sus red — invalid verdicts
@@ -57,20 +61,23 @@ export default {
         },
       },
       {
+        // "Candy Pop" dark — the purple party twin of the pink light theme.
+        // Deep indigo-purple base matches the new purple background; condiments
+        // stay neon for energy.
         "logadog-night": {
           primary: "#FFD428", // neon mustard
-          "primary-content": "#16110D",
+          "primary-content": "#1A1140",
           secondary: "#FF4D3D", // bright ketchup
-          "secondary-content": "#16110D",
+          "secondary-content": "#1A1140",
           accent: "#6FCB5A", // bright relish
-          "accent-content": "#16110D",
-          neutral: "#2A211A",
-          "neutral-content": "#FFF8EC",
-          "base-100": "#16110D", // char — stadium at night
-          "base-200": "#221913",
-          "base-300": "#2F231A",
-          "base-content": "#F6ECD8",
-          info: "#7FB7D9",
+          "accent-content": "#1A1140",
+          neutral: "#3A2A6B", // purple — dark surfaces
+          "neutral-content": "#F3E9FF",
+          "base-100": "#1A1140", // deep indigo-purple — party at night
+          "base-200": "#271858", // purple — cards
+          "base-300": "#341E6E",
+          "base-content": "#F3E9FF", // soft lavender ink
+          info: "#A78BFA", // periwinkle
           success: "#6FCB5A",
           warning: "#FFD428",
           error: "#FF5C6E",


### PR DESCRIPTION
## What & why

The app's background art (`app-bg`) is **candy-pop / Memphis** — soft pink/purple gradients, floating bubbles, confetti — but the DaisyUI theme dressed the UI in warm ballpark **cream/char**, so the chrome and the backdrop were telling two different stories. This reconciles them.

**Principle:** condiments stay *semantic*; the neutral/base layer goes *candy*.
- **Kept unchanged:** mustard = primary CTA, ketchup = live / rank #1, relish = VALID DOG, sus-red = SUS. These carry meaning in `VoteBar` / leaderboard.
- **Shifted:** `base-100/200/300`, `neutral`, `base-content`, `info` → candy. Light = soft pink-cream base + plum ink; dark = deep indigo-purple "party at night."

## Changes

| File | What |
|---|---|
| `tailwind.config.ts` | Retune both DaisyUI themes' base/neutral/info; condiments untouched. |
| `src/styles/globals.css` | `glass-card` trades the hard black border for a **1px white glass rim + soft shadow** and a lighter `blur(28px)`, so the gradient & bubbles **refract through** the frosted cards. Dark mode wires up a purple background under `prefers-color-scheme: dark`. |
| `src/components/utils/HotdogCard.tsx`, `src/components/Attestation/List.tsx` | Drop the per-card `border-4` black override so the glass rim shows; feed gap `4 → 6` so the gradient peeks between cards. |
| `src/components/utils/BottomNav.tsx` | Condiment-gradient glow ring behind the raised center **Log** button. |
| `docs/REDESIGN.md` | Document the Candy Pop evolution (§11). |

## Light / dark = a real pair

The pink background (`background.png` / `background-dekstop.png`) is light mode; the **purple twin is dark mode**. Dark mode ships with a CSS radial-gradient fallback so it looks right immediately — **drop `public/images/background-dark.png` + `background-dark-desktop.png` in** to layer the floating bubbles/confetti on top. No code change needed for that.

## Scope & verification

- Web app (`src/`) only. The separate React Native app under `mobile/` is intentionally untouched.
- `bun run build` passes type-checking + ESLint (the only build failure is the pre-existing thirdweb `clientId` requirement during page-data collection, unrelated to these visual changes). Not visually verified in-browser — that needs thirdweb creds the build env lacks.

## Follow-up (not in this PR)

Direction B — a "Memphis confetti toolkit": extract the squiggles/dots as reusable SVGs for empty states, loaders, and a confetti burst on a VALID DOG vote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwAuLeu79YistqhZ5Hawt5

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwAuLeu79YistqhZ5Hawt5)_