### PR TITLE
Sticker Brutalism, app-wide

### DIFF
--- a/src/components/Attestation/List.tsx
+++ b/src/components/Attestation/List.tsx
@@ -319,7 +319,7 @@ export const ListAttestations: FC<Props> = ({ limit }) => {
       <div id="top-of-list" className="invisible" />
       <div className="flex flex-col gap-4">
       {/* Live scoreboard ticker — always shows all-time top dogs */}
-      <div className="overflow-hidden rounded-2xl border border-base-content/10 bg-base-100/60 backdrop-blur-sm">
+      <div className="pop-card w-full overflow-hidden rounded-2xl bg-base-100">
         <LeaderboardBanner scrollSpeed={40} />
       </div>
       <div className="flex justify-end">

--- a/src/components/LeaderboardList.tsx
+++ b/src/components/LeaderboardList.tsx
@@ -85,7 +85,7 @@ const LeaderboardListComponent: FC<LeaderboardListProps> = ({
   }, [leaderboard?.users, profiles]);
 
   if (!leaderboard || !profiles)
-    return <div className="grill-skeleton w-full animate-grill-shimmer rounded-2xl" style={{ height }} />;
+    return <div className="pop-card grill-skeleton w-full animate-grill-shimmer rounded-2xl" style={{ height }} />;
 
   const addresses = leaderboard.users ?? [];
   const hotdogs = leaderboard.hotdogs ?? [];
@@ -128,18 +128,14 @@ const LeaderboardListComponent: FC<LeaderboardListProps> = ({
               <Link
                 key={address}
                 href={`/profile/address/${address}`}
-                className={`${style.order} flex flex-col items-center gap-1 rounded-3xl bg-base-200 p-3 ${style.glow} ${
-                  isFirst ? "pb-6" : ""
+                className={`${style.order} pop-card flex flex-col items-center gap-1 rounded-3xl p-3 ${
+                  isFirst ? "bg-primary pb-6 text-primary-content" : "bg-base-200"
                 }`}
               >
                 <span className="text-2xl">{style.medal}</span>
-                <motion.div
-                  className={`rounded-full ring-4 ${style.ring}`}
-                  animate={isFirst ? { boxShadow: ["0 0 0px #F5C518", "0 0 18px #F5C518", "0 0 0px #F5C518"] } : undefined}
-                  transition={isFirst ? { duration: 2.4, repeat: Infinity } : undefined}
-                >
+                <div className="pop-frame overflow-hidden rounded-full">
                   <LbAvatar profile={profile} address={address} size={isFirst ? 64 : 48} />
-                </motion.div>
+                </div>
                 <span className="max-w-full truncate text-xs font-semibold">
                   {nameFor(profile, address)}
                 </span>
@@ -153,16 +149,16 @@ const LeaderboardListComponent: FC<LeaderboardListProps> = ({
       )}
 
       <div
-        className="w-full space-y-2 overflow-y-auto rounded-2xl bg-base-200/40 p-3 backdrop-blur-sm"
+        className="pop-card w-full space-y-2 overflow-y-auto rounded-2xl bg-base-100 p-3"
         style={{ maxHeight: height }}
       >
         {currentUserRow && (
           <motion.div
             layout
-            className="flex items-center justify-between gap-2 rounded-2xl bg-primary/15 p-3 ring-1 ring-primary/40"
+            className="flex items-center justify-between gap-2 rounded-xl border-2 border-base-content bg-primary/25 p-3"
           >
             <Link href={`/profile/address/${currentUserRow.address}`} className="flex items-center gap-3">
-              <span className="w-10 text-center font-display text-2xl tabular-nums text-secondary">
+              <span className="flex h-9 w-9 items-center justify-center rounded-lg border-2 border-base-content bg-primary font-display text-base tabular-nums text-primary-content">
                 {currentUserRow.rank}
               </span>
               <LbAvatar profile={profileMap.get(currentUserRow.address.toLowerCase())} address={currentUserRow.address} size={28} />
@@ -184,10 +180,10 @@ const LeaderboardListComponent: FC<LeaderboardListProps> = ({
               key={address}
               layout
               transition={{ type: "spring", stiffness: 500, damping: 40 }}
-              className="flex items-center justify-between gap-2 rounded-2xl bg-base-200/60 p-3 transition-colors hover:bg-base-300"
+              className="flex items-center justify-between gap-2 rounded-xl border-2 border-base-content bg-base-100 p-3 transition-colors hover:bg-base-200"
             >
               <Link href={`/profile/address/${address}`} className="flex items-center gap-3">
-                <span className="w-10 text-center font-display text-2xl tabular-nums text-secondary">
+                <span className="flex h-9 w-9 items-center justify-center rounded-lg border-2 border-base-content bg-base-200 font-display text-base tabular-nums text-secondary">
                   {rank}
                 </span>
                 <LbAvatar profile={profile} address={address} size={28} />

--- a/src/components/utils/BottomNav.tsx
+++ b/src/components/utils/BottomNav.tsx
@@ -67,7 +67,7 @@ export const BottomNav: FC = () => {
               whileTap={{ scale: 0.9 }}
               whileHover={{ scale: 1.05 }}
               transition={{ type: "spring", stiffness: 400, damping: 12 }}
-              className="pop-card -mt-8 h-16 w-16 overflow-hidden rounded-full"
+              className="-mt-8 h-16 w-16 overflow-hidden rounded-full border-4 border-base-content"
             >
               <Image
                 src="/images/hotdog-icon.png"

--- a/src/components/utils/BottomNav.tsx
+++ b/src/components/utils/BottomNav.tsx
@@ -44,7 +44,7 @@ export const BottomNav: FC = () => {
           Log button below opens it. No inline trigger or FAB. */}
       <CreateAttestation showTriggers={false} />
 
-      <nav className="fixed bottom-0 left-0 right-0 z-50 border-t border-base-content/10 bg-base-100/80 backdrop-blur-lg">
+      <nav className="fixed bottom-0 left-0 right-0 z-50 border-t-[3px] border-base-content bg-base-100">
         <div className="mx-auto grid h-20 max-w-md grid-cols-5 items-center px-2 pb-2">
           <NavButton
             emoji="🌭"
@@ -67,7 +67,7 @@ export const BottomNav: FC = () => {
               whileTap={{ scale: 0.9 }}
               whileHover={{ scale: 1.05 }}
               transition={{ type: "spring", stiffness: 400, damping: 12 }}
-              className="-mt-8 h-16 w-16 overflow-hidden rounded-full border-4 border-base-100 shadow-dog-lg"
+              className="pop-card -mt-8 h-16 w-16 overflow-hidden rounded-full"
             >
               <Image
                 src="/images/hotdog-icon.png"

--- a/src/components/utils/Layout.tsx
+++ b/src/components/utils/Layout.tsx
@@ -19,7 +19,7 @@ export const Layout: FC<LayoutProps> = ({ children }) => {
     <div className="app-bg block min-h-screen">
       <div className="mx-auto min-h-screen max-w-7xl overflow-x-hidden pb-24">
         {/* Slim sticky scoreboard header — brand left, season/day right. */}
-        <header className="sticky top-0 z-40 border-b border-base-content/10 bg-base-100/70 backdrop-blur-lg">
+        <header className="sticky top-0 z-40 border-b-[3px] border-base-content bg-base-100">
           <div className="mx-auto flex max-w-2xl items-center justify-between px-4 py-2">
             <Link href="/" className="flex shrink-0 items-center">
               <Image
@@ -42,18 +42,18 @@ export const Layout: FC<LayoutProps> = ({ children }) => {
             <div className="flex items-center gap-2 font-display text-xs tracking-wider">
               <Link
                 href="/rules"
-                className="rounded-full bg-base-200 px-2.5 py-1"
+                className="rounded-full border-2 border-base-content bg-base-200 px-2.5 py-1"
               >
                 RULES
               </Link>
               <Link
                 href="/earn"
-                className="rounded-full bg-base-200 px-2.5 py-1"
+                className="rounded-full border-2 border-base-content bg-base-200 px-2.5 py-1"
               >
                 $HOTDOG
               </Link>
               {mounted && (
-                <span className="rounded-full bg-primary/20 px-2.5 py-1 text-primary">
+                <span className="rounded-full border-2 border-base-content bg-primary px-2.5 py-1 text-primary-content">
                   {isLive ? `DAY ${day}` : "PRE-SEASON"}
                 </span>
               )}

--- a/src/pages/dog/DogPageComponent.tsx
+++ b/src/pages/dog/DogPageComponent.tsx
@@ -37,7 +37,7 @@ const DogPage: NextPage<{ logId: string }> = ({ logId }) => {
           <meta name="fc:frame" content={JSON.stringify(miniAppMetadata)} />
         </Head>
         <main className="flex flex-col items-center justify-center">
-          <div className="w-64 h-64 bg-base-300 animate-pulse rounded-lg" />
+          <div className="pop-card w-64 h-64 bg-base-300 animate-pulse rounded-2xl" />
         </main>
       </>
     );

--- a/src/pages/earn.tsx
+++ b/src/pages/earn.tsx
@@ -51,7 +51,7 @@ const EarnPage: NextPage = () => {
           </div>
 
           {/* Token acquisition */}
-          <div className="glass-card rounded-3xl p-5 text-center">
+          <div className="pop-card rounded-3xl bg-base-100 p-5 text-center">
             <p className="mb-3 text-sm opacity-70">Need some $HOTDOG?</p>
             <Buy />
             <div className="mt-3">
@@ -74,8 +74,8 @@ const EarnPage: NextPage = () => {
           </div>
 
           {/* Staking */}
-          <div className="glass-card rounded-3xl p-5">
-            <div role="tablist" className="tabs tabs-boxed mb-4 bg-base-200">
+          <div className="pop-card rounded-3xl bg-base-100 p-5">
+            <div role="tablist" className="tabs tabs-boxed mb-4 border-2 border-base-content bg-base-200">
               <a
                 role="tab"
                 className={`tab font-display tracking-wide ${stakeTab === "stake" ? "tab-active" : ""}`}
@@ -95,7 +95,7 @@ const EarnPage: NextPage = () => {
           </div>
 
           {/* How Earning Works */}
-          <div className="glass-card rounded-3xl p-5">
+          <div className="pop-card rounded-3xl bg-base-100 p-5">
             <h2 className="mb-3 font-display text-2xl font-bold tracking-tight">💡 HOW IT WORKS</h2>
 
             <Image
@@ -127,7 +127,7 @@ const EarnPage: NextPage = () => {
               </form>
             </dialog>
 
-            <div role="tablist" className="tabs tabs-boxed mb-4 bg-base-200">
+            <div role="tablist" className="tabs tabs-boxed mb-4 border-2 border-base-content bg-base-200">
               <a
                 role="tab"
                 className={`tab font-display tracking-wide ${mode === "eat" ? "tab-active" : ""}`}
@@ -199,10 +199,10 @@ const EarnPage: NextPage = () => {
           </div>
 
           {/* Judging Guidelines */}
-          <div className="glass-card rounded-3xl p-5">
+          <div className="pop-card rounded-3xl bg-base-100 p-5">
             <div className="mb-3 flex items-center justify-between">
               <h2 className="font-display text-2xl font-bold tracking-tight">🧑‍⚖️ JUDGING RULES</h2>
-              <Link href="/judges" className="btn btn-outline btn-sm font-display tracking-wide">
+              <Link href="/judges" className="pop-btn flex items-center gap-1 rounded-lg bg-base-100 px-3 py-1.5 font-display text-sm tracking-wide">
                 <TrophyIcon className="h-4 w-4" />
                 Judges
               </Link>
@@ -235,7 +235,7 @@ const EarnPage: NextPage = () => {
           </div>
 
           {/* Voting Process */}
-          <div className="glass-card rounded-3xl p-5">
+          <div className="pop-card rounded-3xl bg-base-100 p-5">
             <h2 className="mb-4 font-display text-2xl font-bold tracking-tight">⚡ VOTING PROCESS</h2>
             <div className="grid grid-cols-3 gap-4 text-center">
               <div>
@@ -281,13 +281,13 @@ const EarnPage: NextPage = () => {
           </div>
 
           {/* Claim Trading Rewards */}
-          <div className="glass-card rounded-3xl p-5">
+          <div className="pop-card rounded-3xl bg-base-100 p-5">
             <h2 className="mb-3 font-display text-2xl font-bold tracking-tight">🎁 TRADING REWARDS</h2>
             <ClaimProtocolRewards />
           </div>
 
           {/* Airdrop */}
-          <div className="glass-card rounded-3xl p-5">
+          <div className="pop-card rounded-3xl bg-base-100 p-5">
             <h2 className="mb-1 font-display text-2xl font-bold tracking-tight">🪂 AIRDROP</h2>
             <p className="mb-3 text-sm opacity-70">
               3M $HOTDOG for Glizzy Zone and Log a Dog Channel followers

--- a/src/pages/judges.tsx
+++ b/src/pages/judges.tsx
@@ -104,7 +104,7 @@ const JudgesPage: NextPage = () => {
               </AnimatePresence>
               {queue.length > 1 && (
                 <div className="mt-3 flex justify-center">
-                  <button className="btn btn-ghost btn-sm font-display tracking-wide" onClick={next}>
+                  <button className="pop-btn rounded-lg bg-base-100 px-3 py-1.5 font-display text-sm tracking-wide" onClick={next}>
                     Skip to next dog →
                   </button>
                 </div>
@@ -116,9 +116,9 @@ const JudgesPage: NextPage = () => {
           <div className="w-full">
             <h2 className="mb-3 mt-4 font-display text-2xl font-bold tracking-tight">🏅 TOP JUDGES</h2>
             {loadingJudges ? (
-              <div className="space-y-2 rounded-2xl bg-base-200/40 p-3 backdrop-blur-sm">
+              <div className="pop-card space-y-2 rounded-2xl bg-base-100 p-3">
                 {Array.from({ length: 5 }).map((_, i) => (
-                  <div key={i} className="flex items-center gap-3 rounded-2xl bg-base-200/60 p-3">
+                  <div key={i} className="flex items-center gap-3 rounded-xl border-2 border-base-content bg-base-100 p-3">
                     <div className="grill-skeleton h-5 w-8 animate-grill-shimmer rounded" />
                     <div className="grill-skeleton h-10 w-10 animate-grill-shimmer rounded-full" />
                     <div className="grill-skeleton h-4 w-32 animate-grill-shimmer rounded-lg" />
@@ -126,28 +126,28 @@ const JudgesPage: NextPage = () => {
                 ))}
               </div>
             ) : judgesErrored ? (
-              <div className="rounded-2xl bg-base-200/40 p-4 text-sm">
+              <div className="pop-card rounded-2xl bg-base-100 p-4 text-sm">
                 <p className="opacity-70">Could not load judge rankings right now.</p>
                 <button className="btn btn-ghost btn-sm mt-2" onClick={() => void refetchJudges()}>
                   Retry rankings
                 </button>
               </div>
             ) : judges.length === 0 ? (
-              <div className="rounded-2xl bg-base-200/40 p-4 text-sm opacity-70">
+              <div className="pop-card rounded-2xl bg-base-100 p-4 text-sm opacity-70">
                 Judge rankings are temporarily unavailable.
               </div>
             ) : (
-              <div className="space-y-2 rounded-2xl bg-base-200/40 p-3 backdrop-blur-sm">
+              <div className="pop-card space-y-2 rounded-2xl bg-base-100 p-3">
                 {judges.map((j, idx) => (
                   <div
                     key={j.voter}
-                    className="flex items-center justify-between gap-2 rounded-2xl bg-base-200/60 p-3 transition-colors hover:bg-base-300"
+                    className="flex items-center justify-between gap-2 rounded-xl border-2 border-base-content bg-base-100 p-3 transition-colors hover:bg-base-300"
                   >
                     <div className="flex items-center gap-3">
-                      <span className="w-8 text-center font-display text-xl tabular-nums text-secondary">
+                      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border-2 border-base-content bg-base-200 font-display text-base tabular-nums text-secondary">
                         {idx + 1}
                       </span>
-                      <div className="h-10 w-10 overflow-hidden rounded-full bg-base-300">
+                      <div className="pop-frame h-10 w-10 overflow-hidden rounded-full bg-base-300">
                         {j.profile.imgUrl ? (
                           <Image
                             src={getProxiedUrl(j.profile.imgUrl)}

--- a/src/pages/leaderboard.tsx
+++ b/src/pages/leaderboard.tsx
@@ -26,7 +26,7 @@ const LeaderboardPage: NextPage = () => {
             🏆 THE SCOREBOARD
           </h1>
 
-          <div role="tablist" className="tabs tabs-boxed bg-base-200">
+          <div role="tablist" className="tabs tabs-boxed border-2 border-base-content bg-base-200">
             {TABS.map((t) => (
               <a
                 key={t}
@@ -39,7 +39,7 @@ const LeaderboardPage: NextPage = () => {
             ))}
           </div>
 
-          <div className="w-full overflow-hidden rounded-2xl border border-base-content/10 bg-base-100/60 backdrop-blur-sm">
+          <div className="pop-card w-full overflow-hidden rounded-2xl bg-base-100">
             <LeaderboardBanner startDate={startDateObj} scrollSpeed={35} />
           </div>
 

--- a/src/pages/profile/[username].tsx
+++ b/src/pages/profile/[username].tsx
@@ -64,19 +64,21 @@ export const Profile: NextPage<{ username: string }> = ({ username }) => {
     <main className="flex flex-col items-center justify-center">
       <div className="container flex flex-col items-center justify-center gap-12 px-4 py-16 ">
         <div className="flex flex-col gap-2">
-          <div className="flex items-center justify-between mb-8">
+          <div className="pop-card mb-8 flex items-center justify-between gap-3 rounded-2xl bg-base-100 p-4">
             <div className="flex items-center gap-4">
-              <CustomMediaRenderer
-                src={displayImage ?? ""}
-                alt={displayUsername ?? ""}
-                className="rounded-full"
-                width={"48px"}
-                height={"48px"}
-                client={client}
-              />
-              <h1 className="text-2xl font-bold">{displayUsername}</h1>
+              <span className="pop-frame inline-flex overflow-hidden rounded-full">
+                <CustomMediaRenderer
+                  src={displayImage ?? ""}
+                  alt={displayUsername ?? ""}
+                  className="rounded-full"
+                  width={"48px"}
+                  height={"48px"}
+                  client={client}
+                />
+              </span>
+              <h1 className="font-display text-2xl tracking-wide">{displayUsername}</h1>
             </div>
-            <button className={`btn btn-ghost btn-xs ${isOwnProfile ? '' : 'hidden'}`} onClick={() => setShowProfileForm(!showProfileForm)}>
+            <button className={`pop-btn rounded-lg bg-base-100 px-3 py-1 font-display text-xs ${isOwnProfile ? '' : 'hidden'}`} onClick={() => setShowProfileForm(!showProfileForm)}>
               {showProfileForm ? 'Cancel Edit' : 'Edit Profile'}
             </button>
           </div>

--- a/src/pages/profile/address/[address].tsx
+++ b/src/pages/profile/address/[address].tsx
@@ -112,7 +112,7 @@ export const Profile: NextPage<{ address: string }> = ({ address }) => {
   const renderHotdogSkeletons = () => (
     <div className="grid md:grid-cols-2 grid-cols-1 gap-4">
       {Array.from({ length: limit }).map((_, index) => (
-        <div className="card p-4 bg-base-200 bg-opacity-50" key={index}>
+        <div className="card pop-card bg-base-100 p-4" key={index}>
           <div className="flex gap-2 items-center">
             <div className="h-10 w-10 bg-base-300 animate-pulse rounded-full" />
             <div className="h-4 w-20 bg-base-300 animate-pulse rounded-lg" />
@@ -190,15 +190,17 @@ export const Profile: NextPage<{ address: string }> = ({ address }) => {
     <main className="flex flex-col items-center px-4 pt-6">
       <div className="flex w-full max-w-xl flex-col gap-6">
         {/* Stat hero */}
-        <div className="flex flex-col items-center gap-3 rounded-3xl bg-base-200 p-6 text-center shadow-dog">
-          <CustomMediaRenderer
-            src={displayImage ?? ''}
-            alt={displayUsername ?? ''}
-            className="rounded-full ring-4 ring-primary/40"
-            width={"88px"}
-            height={"88px"}
-            client={client}
-          />
+        <div className="pop-card flex flex-col items-center gap-3 rounded-3xl bg-base-200 p-6 text-center">
+          <span className="pop-frame inline-flex overflow-hidden rounded-full">
+            <CustomMediaRenderer
+              src={displayImage ?? ''}
+              alt={displayUsername ?? ''}
+              className="rounded-full"
+              width={"88px"}
+              height={"88px"}
+              client={client}
+            />
+          </span>
           <h1 className="font-display text-3xl tracking-wide">{displayUsername ?? `${address.slice(0, 6)}...${address.slice(-4)}`}</h1>
           <div className="flex items-center gap-2">
             <span className="font-display text-4xl tabular-nums leading-none">
@@ -208,7 +210,7 @@ export const Profile: NextPage<{ address: string }> = ({ address }) => {
           </div>
           {isOwnProfile && (
             <button
-              className="btn btn-ghost btn-xs"
+              className="pop-btn rounded-lg bg-base-100 px-3 py-1 font-display text-xs"
               onClick={() => setShowProfileForm(!showProfileForm)}
             >
               {showProfileForm ? 'Cancel' : hasNoAvatar ? 'Add Avatar' : 'Edit Profile'}

--- a/src/pages/profile/id/[id].tsx
+++ b/src/pages/profile/id/[id].tsx
@@ -65,19 +65,21 @@ export const Profile: NextPage<{ id: string }> = ({ id }) => {
     <main className="flex flex-col items-center justify-center">
       <div className="container flex flex-col items-center justify-center gap-12 px-4 py-16 ">
         <div className="flex flex-col gap-2">
-          <div className="flex items-center justify-between mb-8">
+          <div className="pop-card mb-8 flex items-center justify-between gap-3 rounded-2xl bg-base-100 p-4">
             <div className="flex items-center gap-4">
-              <CustomMediaRenderer
-                src={displayImage ?? ""}
-                alt={displayUsername ?? ""}
-                className="rounded-full"
-                width={"48px"}
-                height={"48px"}
-                client={client}
-              />
-              <h1 className="text-2xl font-bold">{displayUsername}</h1>
+              <span className="pop-frame inline-flex overflow-hidden rounded-full">
+                <CustomMediaRenderer
+                  src={displayImage ?? ""}
+                  alt={displayUsername ?? ""}
+                  className="rounded-full"
+                  width={"48px"}
+                  height={"48px"}
+                  client={client}
+                />
+              </span>
+              <h1 className="font-display text-2xl tracking-wide">{displayUsername}</h1>
             </div>
-            <button className={`btn btn-ghost btn-xs ${isOwnProfile ? '' : 'hidden'}`} onClick={() => setShowProfileForm(!showProfileForm)}>
+            <button className={`pop-btn rounded-lg bg-base-100 px-3 py-1 font-display text-xs ${isOwnProfile ? '' : 'hidden'}`} onClick={() => setShowProfileForm(!showProfileForm)}>
               {showProfileForm ? 'Cancel Edit' : 'Edit Profile'}
             </button>
           </div>

--- a/src/pages/rules.tsx
+++ b/src/pages/rules.tsx
@@ -36,7 +36,7 @@ const RulesPage: NextPage = () => {
                 animate={{ opacity: 1, x: 0 }}
                 exit={{ opacity: 0, x: -40 }}
                 transition={{ type: "spring", stiffness: 260, damping: 26 }}
-                className="absolute inset-0 flex flex-col items-center justify-center gap-4 rounded-3xl bg-base-200 p-8 text-center shadow-dog"
+                className="pop-card absolute inset-0 flex flex-col items-center justify-center gap-4 rounded-3xl bg-base-200 p-8 text-center"
               >
                 <span className="text-6xl">{card.emoji}</span>
                 <h2 className="font-display text-3xl tracking-wide">{card.title}</h2>
@@ -57,11 +57,11 @@ const RulesPage: NextPage = () => {
           </div>
 
           {last ? (
-            <Link href="/" className="btn btn-primary font-display tracking-wide">
+            <Link href="/" className="pop-btn rounded-xl bg-primary px-5 py-3 font-display tracking-wide text-primary-content">
               START LOGGING 🌭
             </Link>
           ) : (
-            <button className="btn btn-primary font-display tracking-wide" onClick={() => setI((c) => c + 1)}>
+            <button className="pop-btn rounded-xl bg-primary px-5 py-3 font-display tracking-wide text-primary-content" onClick={() => setI((c) => c + 1)}>
               NEXT →
             </button>
           )}


### PR DESCRIPTION
Extends the merged feed redesign (#202) so the **whole app** speaks Sticker Brutalism, not just the feed.

## The system
Reuses the merged `.pop-card` / `.pop-btn` / `.sticker` / `.pop-frame` utilities — thick ink outlines, solid surfaces, hard offset shadows (no blur). For non-`pop-*` elements I used **`border-base-content`** as the outline, which is char in light mode and cream in dark — i.e. the same `--ink` the utilities flip to, so everything stays consistent in both themes.

## What changed (presentation only — no logic)
- **Shared chrome (every page)** — `BottomNav` + sticky `Layout` header get a 3px ink edge and **solid** (de-blurred) backgrounds; the raised center **Log** button is now a `.pop-card`; header pills (`RULES` / `$HOTDOG` / `DAY`) get crisp outlines.
- **Leaderboard** — podium are `.pop-card` blocks (**#1 on a mustard block**), the list is a `.pop-card` with **outlined rows + chip rank numbers**, avatars get ink rings; the page banner + tabs brutalized.
- **Earn** — the **7 `glass-card`s → `.pop-card`**, tabs and the Judges button brutalized.
- **Profiles** (`[username]` / `id` / `address`) — `.pop-card` headers + stat-hero, `.pop-frame` avatars, `.pop-btn` edit buttons, brutalist skeletons.
- **Judges** — `.pop-card` containers, outlined judge rows + rank chips, `.pop-btn` skip control.
- **Rules** carousel cards + **dog detail** loader brutalized.

## Notes
- `bun run build` passes type-check + ESLint (only the pre-existing thirdweb `clientId` page-data step fails, unrelated). Not browser-verified — needs thirdweb creds this env lacks.
- **Follow-ups** (intentionally not in this PR): the FAQ `Help/*` sub-components, the Log/upload modal (`Create.tsx`), `Stake/*`, and the auth/`Connect` buttons. Happy to do those next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwAuLeu79YistqhZ5Hawt5

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwAuLeu79YistqhZ5Hawt5)_