### PR TITLE
Sticker Brutalism follow-ups: Log modal, stake, auth, FAQ

### DIFF
--- a/src/components/Attestation/Create.tsx
+++ b/src/components/Attestation/Create.tsx
@@ -313,14 +313,14 @@ const CreateAttestationComponent: FC<Props> = ({ onAttestationCreated, showTrigg
           the primary Log action and renders this component with showTriggers=false. */}
       {showTriggers && (
         <button
-          className="btn btn-primary font-display tracking-wide"
+          className="pop-btn btn btn-primary font-display tracking-wide"
           onClick={()=>(document.getElementById('create_attestation_modal') as HTMLDialogElement).showModal()}
         >
           Log a Dog
         </button>
       )}
       <dialog id="create_attestation_modal" className="modal modal-bottom sm:modal-middle">
-        <div className="modal-box max-h-[92vh] overflow-y-auto">
+        <div className="modal-box max-h-[92vh] overflow-y-auto border-[3px] border-base-content bg-base-100">
           <h3 className="mb-1 font-display text-3xl tracking-wide">LOG A DOG 🌭</h3>
           <p className="mb-4 text-sm opacity-70">Show us the evidence.</p>
           <div className="flex flex-col gap-3">
@@ -342,7 +342,7 @@ const CreateAttestationComponent: FC<Props> = ({ onAttestationCreated, showTrigg
             <p className="text-center text-xs opacity-40">
               Photos are public and count toward the global leaderboard
             </p>
-            <div className="collapse collapse-arrow w-full rounded-2xl bg-base-200/50">
+            <div className="collapse collapse-arrow w-full rounded-2xl border-2 border-base-content bg-base-200">
               <input type="checkbox" />
               <div className="collapse-title text-sm font-medium opacity-70">
                 Advanced options
@@ -381,7 +381,7 @@ const CreateAttestationComponent: FC<Props> = ({ onAttestationCreated, showTrigg
               <ConnectButton client={client} />
             ) : payOwnGas ? (
               <TransactionButton
-                className="!btn !btn-primary font-display tracking-wide"
+                className="pop-btn !btn !btn-primary font-display tracking-wide"
                 transaction={getTx}
                 onTransactionConfirmed={handleOnSuccess}
                 disabled={!imgUri}
@@ -390,7 +390,7 @@ const CreateAttestationComponent: FC<Props> = ({ onAttestationCreated, showTrigg
               </TransactionButton>
             ) : (
               <button
-                className="btn btn-primary font-display tracking-wide"
+                className="pop-btn btn btn-primary font-display tracking-wide"
                 onClick={logDog}
                 disabled={isDisabled}
               >
@@ -420,14 +420,14 @@ const CreateAttestationComponent: FC<Props> = ({ onAttestationCreated, showTrigg
         />
       )}
       <dialog id="share_cast_modal" className="modal modal-bottom sm:modal-middle">
-        <div className="modal-box">
+        <div className="modal-box border-[3px] border-base-content bg-base-100">
           <h3 className="font-display text-2xl tracking-wide">Share the dog? 🌭</h3>
           <p className="py-3 text-sm opacity-70">Cast it on Farcaster and get the people talking.</p>
           <div className="modal-action">
             <form method="dialog">
               <button className="btn btn-ghost">Skip</button>
             </form>
-            <button className="btn btn-primary font-display tracking-wide" onClick={shareOnFarcaster}>
+            <button className="pop-btn btn btn-primary font-display tracking-wide" onClick={shareOnFarcaster}>
               CAST IT
             </button>
           </div>

--- a/src/components/Help/Instructions.tsx
+++ b/src/components/Help/Instructions.tsx
@@ -21,7 +21,7 @@ export const Instructions: FC = () => {
           </li>
         </ul>
         <div className="w-full justify-center flex items-center">
-          <div className="max-w-xl collapse collapse-arrow border-collapse border w-full bg-base-200 bg-opacity-30">
+          <div className="max-w-xl collapse collapse-arrow w-full border-2 border-base-content bg-base-200">
             <input type="checkbox" className="peer" />
             <div className="collapse-title font-bold">
               Instructional Video

--- a/src/components/Help/Media.tsx
+++ b/src/components/Help/Media.tsx
@@ -8,7 +8,7 @@ export const Media: FC = () => {
       <div className="flex flex-col gap-4">
         <h3 className="text-2xl font-bold mx-auto">Media</h3>
         <div className="w-full justify-center flex flex-col gap-2 items-center">
-          <div className="max-w-xl collapse collapse-arrow border-collapse border w-full bg-base-200 bg-opacity-30">
+          <div className="max-w-xl collapse collapse-arrow w-full border-2 border-base-content bg-base-200">
             <input type="checkbox" />
             <div className="collapse-title font-bold">
               Season 2 Award Ceremony
@@ -28,7 +28,7 @@ export const Media: FC = () => {
               </div>
             </div>
           </div>
-          <div className="max-w-xl collapse collapse-arrow border-collapse border w-full bg-base-200 bg-opacity-30">
+          <div className="max-w-xl collapse collapse-arrow w-full border-2 border-base-content bg-base-200">
             <input type="checkbox" />
             <div className="collapse-title font-bold">
               Podcast Episode
@@ -48,7 +48,7 @@ export const Media: FC = () => {
               </p>
             </div>
           </div>
-          <div className="max-w-xl collapse collapse-arrow border-collapse border w-full bg-base-200 bg-opacity-30">
+          <div className="max-w-xl collapse collapse-arrow w-full border-2 border-base-content bg-base-200">
             <input type="checkbox" /> 
             <div className="collapse-title font-bold">
               Interview with Season 1 Winner: Cool Beans!

--- a/src/components/Help/Rules.tsx
+++ b/src/components/Help/Rules.tsx
@@ -7,7 +7,7 @@ export const Rules: FC = () => {
     <div className="flex flex-col gap-4 w-full max-w-xl">
       <div className="flex flex-col gap-2">
         <h3 className="text-2xl font-bold mx-auto">Rules and FAQs</h3>
-        <div className="collapse collapse-arrow border-collapse border w-full bg-base-200 bg-opacity-30">
+        <div className="collapse collapse-arrow w-full border-2 border-base-content bg-base-200">
           <input type="checkbox" /> 
           <div className="collapse-title font-bold">
             What is Log a Dog?
@@ -35,7 +35,7 @@ export const Rules: FC = () => {
             </ul>
           </div>
         </div>
-        <div className="collapse collapse-arrow border-collapse border w-full bg-base-200 bg-opacity-30">
+        <div className="collapse collapse-arrow w-full border-2 border-base-content bg-base-200">
           <input type="checkbox" /> 
           <div className="collapse-title font-bold">
             What constitutes a hotdog?
@@ -92,7 +92,7 @@ export const Rules: FC = () => {
             </ul>
           </div>
         </div>
-        <div className="collapse collapse-arrow border-collapse border w-full bg-base-200 bg-opacity-30">
+        <div className="collapse collapse-arrow w-full border-2 border-base-content bg-base-200">
           <input type="checkbox" /> 
           <div className="collapse-title font-bold">
             How do I earn from eating hotdogs?
@@ -129,7 +129,7 @@ export const Rules: FC = () => {
             </ul>
           </div>
         </div>
-        <div className="collapse collapse-arrow border-collapse border w-full bg-base-200 bg-opacity-30">
+        <div className="collapse collapse-arrow w-full border-2 border-base-content bg-base-200">
           <input type="checkbox" /> 
           <div className="collapse-title font-bold">
             Why does this exist?

--- a/src/components/Profile/Button.tsx
+++ b/src/components/Profile/Button.tsx
@@ -148,7 +148,7 @@ export const ProfileButton: FC<Props> = ({ onProfileCreated, loginBtnLabel, crea
       </div>
 
       <dialog id="create_profile_modal" className="modal modal-bottom sm:modal-middle">
-        <div className="modal-box relative">
+        <div className="modal-box relative border-[3px] border-base-content bg-base-100">
           <button 
             className="btn btn-circle btn-sm btn-ghost absolute top-4 right-4"
             onClick={()=>(document.getElementById('create_profile_modal') as HTMLDialogElement).close()}

--- a/src/components/Stake/ClaimRewards.tsx
+++ b/src/components/Stake/ClaimRewards.tsx
@@ -63,7 +63,7 @@ export const ClaimRewards: FC = () => {
         <span className="font-mono text-sm">{reward} $HOTDOG</span>
       </div>
       <TransactionButton
-        className="!btn !btn-primary !btn-block"
+        className="pop-btn !btn !btn-primary !btn-block"
         transaction={() =>
           claimRewards({
             contract: stakingContract,
@@ -93,7 +93,7 @@ export const ClaimRewards: FC = () => {
             These rewards are from the previous staking contract and do not count toward the current season.
           </p>
           <TransactionButton
-            className="!btn !btn-outline !btn-block"
+            className="pop-btn !btn !btn-outline !btn-block"
             transaction={() =>
               claimRewards({
                 contract: legacyStakingContract,

--- a/src/components/Stake/InsufficientStake.tsx
+++ b/src/components/Stake/InsufficientStake.tsx
@@ -12,7 +12,7 @@ export const InsufficientStake: FC<Props> = ({ isOpen, onClose }) => {
 
   return (
     <dialog className="modal modal-bottom sm:modal-middle" open={isOpen}>
-      <div className="modal-box relative bg-base-100 bg-opacity-70 backdrop-blur-lg">
+      <div className="modal-box relative border-[3px] border-base-content bg-base-100">
         <button 
           className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
           onClick={onClose}

--- a/src/components/Stake/Stake.tsx
+++ b/src/components/Stake/Stake.tsx
@@ -235,7 +235,7 @@ const StakeComponent: FC<Props> = ({ onStake, hideTitle = false }) => {
       {!hideTitle && <h1 className="mb-4 font-display text-2xl font-bold tracking-tight">Stake $HOTDOG</h1>}
       
       {/* Tabs */}
-      <div className="tabs tabs-boxed mb-4 w-full">
+      <div className="tabs tabs-boxed mb-4 w-full border-2 border-base-content">
         <button
           className={`tab tab-lg flex-1 ${activeTab === "stake" ? "tab-active" : ""}`}
           onClick={() => setActiveTab("stake")}
@@ -373,7 +373,7 @@ const StakeComponent: FC<Props> = ({ onStake, hideTitle = false }) => {
               </div>
             ) : hasApproval ? (
               <TransactionButton
-                className="!btn !btn-primary !btn-block"
+                className="pop-btn !btn !btn-primary !btn-block"
                 transaction={() =>
                   stake({
                     contract: stakingContract,
@@ -409,7 +409,7 @@ const StakeComponent: FC<Props> = ({ onStake, hideTitle = false }) => {
               </TransactionButton>
             ) : (
               <TransactionButton
-                className="!btn !btn-primary !btn-block"
+                className="pop-btn !btn !btn-primary !btn-block"
                 transaction={() =>
                   approve({
                     contract: getContract({

--- a/src/components/utils/SignIn.tsx
+++ b/src/components/utils/SignIn.tsx
@@ -73,7 +73,7 @@ const SignInWithEthereum: FC<Props> = ({ btnLabel, defaultOpen = false, buttonCl
       {`${btnLabel ?? 'Vow to play with honor'}`}
     </button>
     <dialog id={`sign_in_modal`} className="modal">
-      <div className="modal-box relative">
+      <div className="modal-box relative border-[3px] border-base-content bg-base-100">
         <button 
           className="btn btn-circle btn-sm btn-ghost absolute top-4 right-4"
           onClick={()=>(document.getElementById(`sign_in_modal`) as HTMLDialogElement).close()}


### PR DESCRIPTION
The follow-up surfaces called out in #205 — the form/modal-heavy bits — now in Sticker Brutalism too. Independent of #205 (touches different files), so the two can merge in any order.

## What changed (presentation only)
- **Log / upload ceremony** (`Create.tsx`) — the **LOG A DOG** modal and the share modal get a 3px ink frame on a solid surface; the *Advanced options* collapse is outlined; **LOG IT** / **CAST IT** become `pop-btn`.
- **Stake + Claim Rewards** — tabs outlined; stake / claim / withdraw buttons → `pop-btn`.
- **InsufficientStake** modal — ink frame (dropped the frosted blur).
- **Auth modals** — `SignIn` and the create-profile modal get ink frames.
- **FAQ `Help/*`** (Rules, Instructions, Media) — accordions become outlined blocks.

## Notes
- Modals use `border-[3px] border-base-content` (a utility, so it reliably overrides DaisyUI's component border, and `base-content` = char/cream → matches `--ink` in both themes).
- A few buttons here are thirdweb `TransactionButton`s styled with DaisyUI's `!btn` (important). I added `pop-btn` so they pick up the hard shadow + press; if any of their `!important` styles win and a button still looks un-brutalist in the browser, it's a one-line tweak — flag it and I'll force it.
- `bun run build` passes type-check + ESLint (only the pre-existing thirdweb `clientId` page-data step fails, unrelated). Not browser-verified — needs creds this env lacks.

With this + #205 + the merged feed, the brutalist language now covers the whole app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwAuLeu79YistqhZ5Hawt5

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwAuLeu79YistqhZ5Hawt5)_