### PR TITLE
Polish: bold names/nav/rules, back button bottom-right, fix profile address 500

### DIFF
--- a/src/components/Attestation/Comments.tsx
+++ b/src/components/Attestation/Comments.tsx
@@ -80,9 +80,9 @@ export const Comments: FC<Props> = ({ logId, metadataUri }) => {
 
   return (
     <>
-      <label htmlFor={`${logId}-comments`} className="btn btn-ghost btn-xs font-normal flex items-center gap-1">
-        <span className="font-semibold">{data?.conversation?.cast?.direct_replies.length}</span>
-        <ChatBubbleLeftRightIcon className="h-4 w-4" />
+      <label htmlFor={`${logId}-comments`} className="btn btn-ghost btn-xs font-bold flex items-center gap-1">
+        <span className="font-bold">{data?.conversation?.cast?.direct_replies.length}</span>
+        <ChatBubbleLeftRightIcon className="h-4 w-4 stroke-2" />
       </label>
 
       <Portal>

--- a/src/components/utils/BottomNav.tsx
+++ b/src/components/utils/BottomNav.tsx
@@ -30,7 +30,7 @@ const NavButton: FC<{
     <div className="relative flex items-center justify-center">
       <span className="text-xl leading-none">{emoji}</span>
     </div>
-    <span className="font-display text-[0.65rem] tracking-wide">{label}</span>
+    <span className="font-display text-[0.65rem] font-bold tracking-wide">{label}</span>
   </button>
 );
 

--- a/src/components/utils/HotdogCard.tsx
+++ b/src/components/utils/HotdogCard.tsx
@@ -248,7 +248,7 @@ const HotdogCardComponent: FC<Props> = ({
                 <span className="pop-frame inline-flex overflow-hidden rounded-full">
                   <Avatar address={hotdog.eater} fallbackSize={28} />
                 </span>
-                <span className="truncate font-display text-base tracking-wide">
+                <span className="truncate font-display text-base font-bold tracking-wide">
                   {displayName}
                 </span>
               </Link>
@@ -348,16 +348,9 @@ const HotdogCardComponent: FC<Props> = ({
             </div>
 
             {/* BACK */}
-            <div className="flip-face flip-back pop-frame flex flex-col gap-2 overflow-y-auto rounded-2xl bg-base-200 p-3">
-              <div className="flex items-center justify-between">
+            <div className="flip-face flip-back pop-frame relative flex flex-col gap-2 overflow-y-auto rounded-2xl bg-base-200 p-3">
+              <div className="flex items-center">
                 <span className="font-display text-sm tracking-wide">📊 #{hotdog.logId.toString()} STATS</span>
-                <button
-                  onClick={flip}
-                  aria-label="Flip card back"
-                  className="pop-btn rounded-lg bg-base-100 px-2 py-0.5 font-display text-xs tracking-wide"
-                >
-                  ↩ BACK
-                </button>
               </div>
 
               {/* Market data (moved here from the old bottom collapsible) */}
@@ -448,6 +441,15 @@ const HotdogCardComponent: FC<Props> = ({
                   </div>
                 )}
               </div>
+
+              {/* Back button — bottom-right, mirroring where STATS ⤺ is on the front */}
+              <button
+                onClick={flip}
+                aria-label="Flip card back"
+                className="pop-btn absolute bottom-3 right-3 rounded-lg bg-base-100 px-2.5 py-1 font-display text-xs tracking-wide"
+              >
+                ↩ BACK
+              </button>
             </div>
           </div>
         </div>

--- a/src/pages/profile/[username].tsx
+++ b/src/pages/profile/[username].tsx
@@ -16,6 +16,16 @@ const CustomMediaRenderer = dynamic(
 );
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { username } = context.params as { username: string };
+
+  if (/^0x[a-fA-F0-9]{40}$/.test(username)) {
+    return {
+      redirect: {
+        destination: `/profile/address/${username}`,
+        permanent: false,
+      },
+    };
+  }
+
   return {
     props: {
       username,

--- a/src/pages/rules.tsx
+++ b/src/pages/rules.tsx
@@ -40,7 +40,7 @@ const RulesPage: NextPage = () => {
               >
                 <span className="text-6xl">{card.emoji}</span>
                 <h2 className="font-display text-3xl tracking-wide">{card.title}</h2>
-                <p className="opacity-80">{card.body}</p>
+                <p className="font-bold opacity-80">{card.body}</p>
               </motion.div>
             </AnimatePresence>
           </div>


### PR DESCRIPTION
## Summary

- **Bold display name** on feed cards next to the avatar
- **↩ BACK button moves to bottom-right** of the flipped card back, matching the position of STATS ⤺ on the front so the user's thumb doesn't have to travel
- **Bold nav labels** in the bottom nav bar
- **Bold body text** on the rules page carousel cards
- **Bolder comment icon** — `stroke-2` + `font-bold` on the trigger label
- **Fix 500 on `/profile/0x…`** — `getServerSideProps` now detects Ethereum addresses and redirects to `/profile/address/[address]` instead of calling `getByUsername` with an address (which errored)

## Test plan
- [ ] Feed cards: display name next to avatar is visibly bold
- [ ] Flip a card → click STATS ⤺ (bottom-right) → ↩ BACK appears at bottom-right of the back face
- [ ] Bottom nav labels are bold
- [ ] Rules page card body text is bold
- [ ] Comment count/icon on cards is bolder
- [ ] Visit `/profile/0x225b1aa72e0290a8a8461267270fd2ac7414e275` → redirects to `/profile/address/0x225b…` without 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwAuLeu79YistqhZ5Hawt5

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwAuLeu79YistqhZ5Hawt5)_