### PR TITLE
Smooth optimistic→real swap when logging a dog

### DIFF
--- a/src/components/Attestation/Create.tsx
+++ b/src/components/Attestation/Create.tsx
@@ -119,16 +119,16 @@ const CreateAttestationComponent: FC<Props> = ({ onAttestationCreated, showTrigg
     return initialUrlsRef.current;
   }, [imgUri]);
 
-  // Query for dog event when we have a transaction hash
+  // Query for dog event when we have a transaction hash. We intentionally do NOT
+  // remove the pending (optimistic) card here: removing it the instant the tx is
+  // indexed races the feed refetch and makes the card vanish then pop back in.
+  // The feed now dedupes the pending card against real data by imageUri and
+  // removes it from the store only once the real row is present, so the swap is
+  // seamless. This query is still needed to drive the Farcaster share modal.
   const { data: dogEvent } = api.hotdog.getDogEventByTransactionHash.useQuery(
     { transactionHash: transactionHash! },
     {
       enabled: !!transactionHash && isTransactionIdResolved,
-      onSuccess: () => {
-        if (transactionId) {
-          removePendingDog(transactionId);
-        }
-      },
     }
   );
 

--- a/src/components/Attestation/List.tsx
+++ b/src/components/Attestation/List.tsx
@@ -399,7 +399,7 @@ export const ListAttestations: FC<Props> = ({ limit }) => {
         // for real) to avoid collisions on duplicate images / concurrent logs.
         const justLanded = !isPending && pendingImageUris.has(hotdog.imageUri);
         const key = isPending
-          ? `pending-${(hotdog as PendingDogEvent).transactionId}`
+          ? `pending-${hotdog.transactionId}`
           : hotdog.logId;
 
         return (

--- a/src/components/Attestation/List.tsx
+++ b/src/components/Attestation/List.tsx
@@ -82,7 +82,7 @@ type Props = {
 export const ListAttestations: FC<Props> = ({ limit }) => {
   const limitOrDefault = limit ?? 4;
   const isClient = typeof window !== 'undefined';
-  const { getPendingDogsForChain, clearExpiredPending } = usePendingTransactionsStore();
+  const { getPendingDogsForChain, clearExpiredPending, removePendingDog } = usePendingTransactionsStore();
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
@@ -171,18 +171,70 @@ export const ListAttestations: FC<Props> = ({ limit }) => {
     return dogData?.pages.flatMap((page) => page.hotdogs) ?? [];
   }, [dogData?.pages]);
 
-  // Smart deduplication: only filter out optimistic data when real data with same logId exists
+  // Match optimistic cards to real rows by imageUri, not the temporary logId.
+  // The optimistic logId is the tx id (a "weird id") which never equals the real
+  // on-chain numeric logId, so a logId-based match never fired and the card only
+  // disappeared via a timer/explicit removal — causing the jarring gap. imageUri
+  // is byte-identical across the round-trip (raw ipfs:// upload → on-chain arg →
+  // DB → getAll), so it's a reliable key.
+  const realImageUris = useMemo(
+    () => new Set(loadedHotdogs.map(h => h.imageUri)),
+    [loadedHotdogs],
+  );
+
+  // Raw pending imageUris (before dedup) — used to spot a real row that just
+  // replaced an optimistic card so we can suppress its entrance animation.
+  const pendingImageUris = useMemo(
+    () => new Set(pendingDogs.map((p: PendingDogEvent) => p.imageUri)),
+    [pendingDogs],
+  );
+
+  // Smart deduplication: drop an optimistic card the moment its real row appears.
   const filteredPendingDogs = useMemo(() => {
-    const realLogIds = new Set(loadedHotdogs.map(h => h.logId));
-    return pendingDogs.filter(pending => {
-      const hasRealData = realLogIds.has(pending.logId);
-      return !hasRealData;
-    });
-  }, [loadedHotdogs, pendingDogs]);
+    return pendingDogs.filter((pending: PendingDogEvent) => !realImageUris.has(pending.imageUri));
+  }, [pendingDogs, realImageUris]);
+
+  // Infer the next on-chain logId so the optimistic card shows "#<next>" instead
+  // of the tx id. max(loaded)+1 doesn't exist yet, so any logId-driven child
+  // query returns empty (no wrong data) and it self-corrects when the real row
+  // lands. Display only — never used as a React key or for navigation.
+  const nextLogIdBase = useMemo(() => {
+    let max = 0n;
+    for (const h of loadedHotdogs) {
+      try {
+        const id = BigInt(h.logId);
+        if (id > max) max = id;
+      } catch {
+        // non-numeric (shouldn't happen for real rows) — skip
+      }
+    }
+    return max;
+  }, [loadedHotdogs]);
+
+  // Optimistic cards rendered newest-first; give the newest the highest inferred id.
+  const displayPendingDogs = useMemo(() => {
+    const len = filteredPendingDogs.length;
+    return filteredPendingDogs.map((pending: PendingDogEvent, i: number) => ({
+      ...pending,
+      logId: (nextLogIdBase + BigInt(len - i)).toString(),
+    }));
+  }, [filteredPendingDogs, nextLogIdBase]);
 
   const allHotdogs: HotdogItem[] = useMemo(() => {
-    return loadedHotdogs.length > 0 ? [...filteredPendingDogs, ...loadedHotdogs] : pendingDogs;
-  }, [filteredPendingDogs, loadedHotdogs, pendingDogs]);
+    return loadedHotdogs.length > 0 ? [...displayPendingDogs, ...loadedHotdogs] : displayPendingDogs;
+  }, [displayPendingDogs, loadedHotdogs]);
+
+  // Remove an optimistic entry from the store once its real row is present. This
+  // tracks reality (the dedup above is the *visual* removal); the 30s expiry
+  // sweep stays only as a failsafe for txs that never index.
+  useEffect(() => {
+    if (loadedHotdogs.length === 0) return;
+    pendingDogs.forEach((pending: PendingDogEvent) => {
+      if (realImageUris.has(pending.imageUri)) {
+        removePendingDog(pending.transactionId);
+      }
+    });
+  }, [realImageUris, pendingDogs, removePendingDog, loadedHotdogs.length]);
 
   // Stable callback so every memoized <HotdogCard> doesn't re-render when this
   // list re-renders (e.g. the 30s expired-pending interval). `refetchDogData`
@@ -340,10 +392,19 @@ export const ListAttestations: FC<Props> = ({ limit }) => {
       {allHotdogs.map((hotdog) => {
         const attestationData = getAttestationData(hotdog);
         const isPending = 'isPending' in hotdog && hotdog.isPending;
-        
+        // A real row whose imageUri is still in the pending store is one that
+        // just replaced an optimistic card. Render it without the drop-in
+        // entrance animation so it settles in place instead of looking like a
+        // second card dropping in. Keys stay unique (tx id for pending, logId
+        // for real) to avoid collisions on duplicate images / concurrent logs.
+        const justLanded = !isPending && pendingImageUris.has(hotdog.imageUri);
+        const key = isPending
+          ? `pending-${(hotdog as PendingDogEvent).transactionId}`
+          : hotdog.logId;
+
         return (
           <HotdogCard
-            key={hotdog.logId}
+            key={key}
             hotdog={hotdog}
             validAttestations={attestationData.validAttestations}
             invalidAttestations={attestationData.invalidAttestations}
@@ -354,6 +415,7 @@ export const ListAttestations: FC<Props> = ({ limit }) => {
             linkToDetail={true}
             showAiJudgement={false}
             disabled={isPending}
+            animateEntrance={!justLanded}
           />
         );
       })}

--- a/src/components/utils/HotdogCard.tsx
+++ b/src/components/utils/HotdogCard.tsx
@@ -104,6 +104,7 @@ type Props = {
   linkToDetail?: boolean; // Whether to link the image to the detail page
   showAiJudgement?: boolean; // Whether to show AI judgement
   disabled?: boolean; // Whether judgement is disabled (for pending)
+  animateEntrance?: boolean; // Drop-in animation on mount; off for cards that just replaced an optimistic one
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -120,6 +121,7 @@ const HotdogCardComponent: FC<Props> = ({
   linkToDetail = false,
   showAiJudgement = false,
   disabled = false,
+  animateEntrance = true,
 }) => {
   const account = useActiveAccount();
   const [flipped, setFlipped] = useState(false);
@@ -232,7 +234,7 @@ const HotdogCardComponent: FC<Props> = ({
 
   return (
     <motion.div
-      initial={{ y: -16, opacity: 0 }}
+      initial={animateEntrance ? { y: -16, opacity: 0 } : false}
       animate={{ y: 0, opacity: 1 }}
       transition={{ type: "spring", stiffness: 260, damping: 24 }}
       className="card pop-card overflow-hidden rounded-[1.75rem] bg-base-100"
@@ -301,7 +303,7 @@ const HotdogCardComponent: FC<Props> = ({
           <div className={`flip-inner ${flipped ? "is-flipped" : ""}`}>
             {/* FRONT */}
             <div className="flip-face pop-frame rounded-2xl bg-base-300">
-              {linkToDetail ? (
+              {linkToDetail && !hotdog.isPending ? (
                 <Link href={`/dog/${hotdog.logId}`} className="block h-full w-full">
                   {Photo}
                 </Link>

--- a/src/stores/pendingTransactions.ts
+++ b/src/stores/pendingTransactions.ts
@@ -47,7 +47,12 @@ export const usePendingTransactionsStore = create<PendingTransactionsStore>()(
       },
       
       clearExpiredPending: () => {
-        const EXPIRY_TIME = 2 * 60 * 1000; // 2 minutes instead of 10 minutes
+        // Pure failsafe for txs that never index. Real cards are now removed the
+        // moment their on-chain row appears (dedup by imageUri in the feed), so
+        // this only needs to catch stuck/failed logs. Keep it generous — if it
+        // fires before a slow CDP index lands, the optimistic card vanishes then
+        // the real one pops back, reintroducing the jank this fix removed.
+        const EXPIRY_TIME = 10 * 60 * 1000; // 10 minutes
         const now = Date.now();
         
         set((state) => ({


### PR DESCRIPTION
## What

Makes the optimistic→real card transition seamless when a user logs a dog. Previously the pending card would vanish, then the real card popped back in with a drop-in animation, and the pending card showed a tx-id "weird id". Now the only indication a dog is loading is the **LOGGING…** sticker in the corner.

## Root causes (all fixed)

1. **Weird id** — pending card was keyed/labeled by the tx id, so dedup-by-logId never matched the real numeric logId.
2. **Disappear/reappear** — `removePendingDog` fired the instant the tx indexed, *before* the refetched feed landed → card vanished, then real one popped back.
3. **Drop-in jank** — the real card remounted with the entrance spring animation → looked like a second card dropping in.

## Changes

**`Create.tsx`** — removed the premature `removePendingDog` in the tx-hash query (the cause of the gap). Query stays to drive the Farcaster share modal.

**`List.tsx`**
- Dedup pending vs real by `imageUri` (verified byte-identical: raw `ipfs://` upload → on-chain arg → DB → `getAll`), not the fake logId. Pending card drops the exact render its real row appears — no gap.
- Inferred `#id` (`max loaded logId + 1`), display-only — never a key or used for navigation.
- `justLanded`: a real row whose imageUri is still in the pending store renders with the entrance animation off, so it settles in place. Keys stay unique (tx id for pending, logId for real) — no morph-by-shared-key collisions.
- Store cleanup driven by real-data-present (effect), not the timer.

**`HotdogCard.tsx`** — new `animateEntrance` prop (off for just-landed cards); guard the `/dog/{id}` detail link while pending (inferred id would 404).

**`pendingTransactions.ts`** — bumped expiry failsafe 2m→10m so a slow CDP index can't expire the card before its real row lands.

Net: same cached image + ENS avatar across the swap; `showLoggedVia` already excludes the server wallet so no "via" row appears → no layout shift.

## Verification

- Touched files typecheck clean. Remaining tsc errors are pre-existing `Cannot find module` (deps not installed in this checkout), not from this change.
- ⚠️ Not visually confirmed at runtime — needs a wallet + Base connection to actually log a dog. Worth a manual pass on the preview deploy before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)