### PR TITLE
Show user verdict on dog cards without re-tapping

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,8 @@
         "@upstash/redis": "^1.38.0",
         "@vercel/og": "^0.6.8",
         "@wagmi/core": "^2.22.1",
-        "@zoralabs/coins-sdk": "0.2.8",
+        "@zoralabs/coins-sdk": "0.7.1",
+        "@zoralabs/protocol-deployments": "0.7.6",
         "cross-fetch": "^4.1.0",
         "csv-parser": "^3.2.1",
         "dotenv": "^16.6.1",
@@ -71,7 +72,7 @@
     },
   },
   "overrides": {
-    "@zoralabs/protocol-deployments": "0.6.1",
+    "@zoralabs/protocol-deployments": "0.7.6",
   },
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.10.1", "", {}, ""],
@@ -812,9 +813,9 @@
 
     "@yr/monotone-cubic-spline": ["@yr/monotone-cubic-spline@1.0.3", "", {}, ""],
 
-    "@zoralabs/coins-sdk": ["@zoralabs/coins-sdk@0.2.8", "", { "dependencies": { "@hey-api/client-fetch": "^0.8.3", "@zoralabs/protocol-deployments": "^0.6.1" }, "peerDependencies": { "abitype": "^1.0.8", "viem": "^2.21.55" } }, "sha512-vni9qcdS6/9HUOue7SDir2wHn+SSSDmxfZhBcCzQWdK9NaW/+E5jCWXuQGFgBzKpLc4FN5ktJz36v92BADQE3g=="],
+    "@zoralabs/coins-sdk": ["@zoralabs/coins-sdk@0.7.1", "", { "dependencies": { "@hey-api/client-fetch": "^0.8.3", "@zoralabs/protocol-deployments": "^0.7.6" }, "peerDependencies": { "abitype": "^1.0.8", "viem": "2.53.1" } }, "sha512-hkVsulBFh4yxFxq7jOGQKp5Y6TbZxHmcU4jYpW1S50HLhe0RbVicNFLCKBdRyh9ssX0TbGbHRbXf02CsCfezsQ=="],
 
-    "@zoralabs/protocol-deployments": ["@zoralabs/protocol-deployments@0.6.1", "", {}, "sha512-iDO5EhLrqDw0keudRq9omuSdvHG852de5/apY2p7QLBDxitQuJ/6/jOaq2WB4B6GPVUh2fTd5+CdoSsbJhJv5g=="],
+    "@zoralabs/protocol-deployments": ["@zoralabs/protocol-deployments@0.7.6", "", {}, "sha512-E8hkSFkpqxttSoH+GQJbcTvjnVQGL+Nlo2WXA3YSkEvzB7Xfv6JOaUxsVZ5ahj0HWD2dwTSw3AucXciIPnTWQQ=="],
 
     "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 

--- a/src/components/Attestation/Judge.tsx
+++ b/src/components/Attestation/Judge.tsx
@@ -8,6 +8,7 @@ import { InsufficientStake } from "../Stake/InsufficientStake";
 import { Portal } from "../utils/Portal";
 import { TransactionStatus } from "../utils/TransactionStatus";
 import { useGhostVote } from "~/hooks/useGhostVote";
+import { useVoterAddress } from "~/hooks/useVoterAddress";
 
 type Props = {
   disabled?: boolean;
@@ -33,6 +34,7 @@ export const JudgeAttestation: FC<Props> = ({
   onAttestationAffirmationRevoked,
 }) => {
   const { data: sessionData } = useSession();
+  const voterAddress = useVoterAddress();
   const utils = api.useUtils();
   const { mutateAsync: refreshFeed } = api.indexer.refreshFeed.useMutation();
   const [isLoadingValidAttestation, setIsLoadingValidAttestation] = useState<boolean>(false);
@@ -44,7 +46,7 @@ export const JudgeAttestation: FC<Props> = ({
   const [isInsufficientStake, setIsInsufficientStake] = useState<boolean>(false);
   const [pendingTransactionId, setPendingTransactionId] = useState<string | null>(null);
 
-  const ghostVote = useGhostVote(logId, sessionData?.user?.address);
+  const ghostVote = useGhostVote(logId, voterAddress);
 
   // ghostVote is null (no vote), true (voted valid), or false (voted sus).
   // ?? cannot be used here: `false ?? x` returns `x`, masking a SUS vote.
@@ -172,8 +174,8 @@ export const JudgeAttestation: FC<Props> = ({
                 } catch (error) {
                   console.warn("Could not refresh indexed votes after attestation", error);
                 }
-                if (sessionData?.user?.address) {
-                  await utils.hotdog.getUserVotes.invalidate({ voter: sessionData.user.address });
+                if (voterAddress) {
+                  await utils.hotdog.getUserVotes.invalidate({ voter: voterAddress });
                 }
                 await utils.hotdog.getJudges.invalidate();
                 void onAttestationMade?.();

--- a/src/components/Attestation/List.tsx
+++ b/src/components/Attestation/List.tsx
@@ -7,6 +7,7 @@ import HotdogCard from "~/components/utils/HotdogCard";
 import { BackToTopButton } from "~/components/utils/BackToTopButton";
 import { LeaderboardBanner } from "~/components/LeaderboardBanner";
 import { DEFAULT_CHAIN } from "~/constants";
+import { useVoterAddress } from "~/hooks/useVoterAddress";
 
 // Types from hotdog router
 type AttestationPeriod = {
@@ -82,6 +83,7 @@ type Props = {
 export const ListAttestations: FC<Props> = ({ limit }) => {
   const limitOrDefault = limit ?? 4;
   const isClient = typeof window !== 'undefined';
+  const voterAddress = useVoterAddress();
   const { getPendingDogsForChain, clearExpiredPending, removePendingDog } = usePendingTransactionsStore();
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
@@ -90,6 +92,7 @@ export const ListAttestations: FC<Props> = ({ limit }) => {
   const queryParams = {
     chainId: DEFAULT_CHAIN.id,
     user: ZERO_ADDRESS, // Always use zero address to get ALL hotdogs for the homepage feed
+    voter: voterAddress ?? ZERO_ADDRESS,
     limit: limitOrDefault,
   };
 

--- a/src/components/Attestation/VoteBar.tsx
+++ b/src/components/Attestation/VoteBar.tsx
@@ -1,7 +1,6 @@
-import { useState, type FC } from "react";
+import { useEffect, useState, type FC } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import { toast } from "react-toastify";
-import { useSession } from "next-auth/react";
 import { getContract, sendTransaction } from "thirdweb";
 import { useActiveWallet } from "thirdweb/react";
 import { sendCalls, getCapabilities } from "thirdweb/wallets/eip5792";
@@ -13,6 +12,7 @@ import { attestToLog } from "~/thirdweb/84532/0xe8c7efdb27480dafe18d49309f4a5e72
 import { InsufficientStake } from "../Stake/InsufficientStake";
 import { Portal } from "../utils/Portal";
 import { useGhostVote } from "~/hooks/useGhostVote";
+import { useVoterAddress } from "~/hooks/useVoterAddress";
 
 type Props = {
   logId: string;
@@ -45,7 +45,7 @@ export const VoteBar: FC<Props> = ({
   userAttestation,
   onAttestationMade,
 }) => {
-  const { data: sessionData } = useSession();
+  const voterAddress = useVoterAddress();
   const wallet = useActiveWallet();
   const utils = api.useUtils();
   const { mutateAsync: refreshFeed } = api.indexer.refreshFeed.useMutation();
@@ -55,12 +55,25 @@ export const VoteBar: FC<Props> = ({
   const [busy, setBusy] = useState<null | "valid" | "invalid">(null);
   const [streak, setStreak] = useState<null | "valid" | "invalid">(null);
 
-  const ghostVote = useGhostVote(logId, sessionData?.user?.address);
+  const ghostVote = useGhostVote(logId, voterAddress);
   // ghostVote is null (no vote), true (voted valid), or false (voted sus).
   // ?? cannot be used here: `false ?? x` returns `x`, masking a SUS vote.
   const effectiveUserAttested = ghostVote !== null || (optimisticUserAttested ?? false);
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const effectiveUserAttestation = ghostVote !== null ? ghostVote : (optimisticUserAttestation ?? false);
+
+  // Keep the locked/highlighted state in sync when server props or indexed votes load.
+  useEffect(() => {
+    if (ghostVote !== null) {
+      setOptimisticUserAttested(true);
+      setOptimisticUserAttestation(ghostVote);
+      return;
+    }
+    if (userAttested) {
+      setOptimisticUserAttested(true);
+      setOptimisticUserAttestation(userAttestation ?? false);
+    }
+  }, [ghostVote, userAttested, userAttestation]);
 
   // Submit the attestation from the user's own wallet. thirdweb Engine is gone,
   // so we mirror Revoke.tsx: build the user-callable `attestToLog`, then prefer
@@ -116,7 +129,7 @@ export const VoteBar: FC<Props> = ({
   // Redis-cached per-user and would otherwise serve a stale `userAttested`,
   // leaving the buttons unlocked and re-votes reverting on-chain.
   const invalidateVoteState = async () => {
-    const voter = sessionData?.user?.address;
+    const voter = voterAddress;
     await Promise.all([
       voter ? utils.hotdog.getUserVotes.invalidate({ voter }) : Promise.resolve(),
       utils.hotdog.getJudges.invalidate(),
@@ -126,7 +139,7 @@ export const VoteBar: FC<Props> = ({
 
   const vote = async (isValid: boolean) => {
     if ((disabled ?? false) || isExpired) return;
-    if (!sessionData?.user?.address || !wallet) {
+    if (!voterAddress || !wallet) {
       toast.error("You must login to judge dogs!");
       return;
     }
@@ -162,6 +175,8 @@ export const VoteBar: FC<Props> = ({
       // our local state was stale (e.g. a cached getById), not a real failure —
       // keep the optimistic "voted" state, lock the buttons, and refresh truth.
       if (/already attested/i.test(message)) {
+        setOptimisticUserAttested(true);
+        setOptimisticUserAttestation(isValid);
         await invalidateVoteState();
         void onAttestationMade?.();
         return;

--- a/src/hooks/useGhostVote.ts
+++ b/src/hooks/useGhostVote.ts
@@ -6,9 +6,9 @@ export function useGhostVote(logId: string | undefined, voter: string | undefine
     { voter: voter ?? "" },
     {
       enabled: !!voter,
-      staleTime: Infinity,
+      staleTime: 60_000,
       retry: false,
-      refetchOnWindowFocus: false,
+      refetchOnWindowFocus: true,
     },
   );
 

--- a/src/hooks/useVoterAddress.ts
+++ b/src/hooks/useVoterAddress.ts
@@ -1,0 +1,14 @@
+import { useMemo } from "react";
+import { useSession } from "next-auth/react";
+import { useActiveAccount } from "thirdweb/react";
+
+/** Connected wallet address, falling back to the next-auth session address. */
+export function useVoterAddress(): string | undefined {
+  const { data: session } = useSession();
+  const account = useActiveAccount();
+
+  return useMemo(
+    () => account?.address ?? session?.user?.address,
+    [account?.address, session?.user?.address],
+  );
+}

--- a/src/pages/judges.tsx
+++ b/src/pages/judges.tsx
@@ -8,9 +8,11 @@ import { api } from "~/utils/api";
 import { getProxiedUrl } from "~/utils/imageProxy";
 import HotdogCard from "~/components/utils/HotdogCard";
 import { ATTESTATION_WINDOW_SECONDS, DEFAULT_CHAIN } from "~/constants";
+import { useVoterAddress } from "~/hooks/useVoterAddress";
 
 const JudgesPage: NextPage = () => {
   const isClient = typeof window !== "undefined";
+  const voterAddress = useVoterAddress();
 
   const {
     data: dogData,
@@ -18,7 +20,7 @@ const JudgesPage: NextPage = () => {
     isError: dogsErrored,
     refetch,
   } = api.hotdog.getAll.useQuery(
-    { chainId: DEFAULT_CHAIN.id, user: ZERO_ADDRESS, start: 0, limit: 50 },
+    { chainId: DEFAULT_CHAIN.id, user: ZERO_ADDRESS, voter: voterAddress ?? ZERO_ADDRESS, start: 0, limit: 50 },
     { enabled: isClient, refetchOnWindowFocus: false, retry: 1 },
   );
 

--- a/src/pages/profile/address/[address].tsx
+++ b/src/pages/profile/address/[address].tsx
@@ -9,6 +9,7 @@ import { useActiveAccount, ConnectButton } from "thirdweb/react";
 import { useSession } from "next-auth/react";
 import { DEFAULT_CHAIN } from "~/constants";
 import HotdogCard from "~/components/utils/HotdogCard";
+import { useVoterAddress } from "~/hooks/useVoterAddress";
 
 const CustomMediaRenderer = dynamic(
   () => import('~/components/utils/CustomMediaRenderer'),
@@ -26,6 +27,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 export const Profile: NextPage<{ address: string }> = ({ address }) => {
   const acccount = useActiveAccount();
   const { data: sessionData } = useSession();
+  const voterAddress = useVoterAddress();
   const { data, isLoading, refetch } = api.profile.getByAddress.useQuery({
     address,
     chainId: DEFAULT_CHAIN.id,
@@ -58,6 +60,11 @@ export const Profile: NextPage<{ address: string }> = ({ address }) => {
       refetchOnMount: false,
       getNextPageParam: (lastPage) => lastPage.nextCursor,
     });
+
+  const { data: userVotes } = api.hotdog.getUserVotes.useQuery(
+    { voter: voterAddress ?? "" },
+    { enabled: !!voterAddress, refetchOnWindowFocus: false },
+  );
 
   // Check if this is the user's own profile
   const isOwnProfile = useMemo(() => {
@@ -141,21 +148,26 @@ export const Profile: NextPage<{ address: string }> = ({ address }) => {
     return (
       <>
         <div className="grid md:grid-cols-2 grid-cols-1 gap-4">
-          {loadedHotdogs.map(({ hotdog, validAttestations, invalidAttestations }, index) => (
+          {loadedHotdogs.map(({ hotdog, validAttestations, invalidAttestations }, index) => {
+            const vote = userVotes?.[hotdog.logId];
+            const userAttested = vote !== undefined;
+            const userAttestation = vote ?? false;
+
+            return (
             <HotdogCard
               key={`${hotdog.logId}-${index}`}
               hotdog={hotdog}
               validAttestations={validAttestations?.toString() ?? "0"}
               invalidAttestations={invalidAttestations?.toString() ?? "0"}
-              userAttested={false}
-              userAttestation={false}
+              userAttested={userAttested}
+              userAttestation={userAttestation}
               chainId={DEFAULT_CHAIN.id}
               onRefetch={handleRefetchDogData}
               linkToDetail={true}
               showAiJudgement={false}
               disabled={false}
             />
-          ))}
+          )})}
         </div>
 
         <div ref={loadMoreRef} className="flex min-h-16 items-center justify-center">

--- a/src/server/api/routers/hotdog.ts
+++ b/src/server/api/routers/hotdog.ts
@@ -358,12 +358,15 @@ export const hotdogRouter = createTRPCRouter({
     .input(z.object({ 
       chainId: z.number(),
       user: z.string(),
+      /** Optional voter address for per-user attestation state without filtering the feed. */
+      voter: z.string().optional(),
       start: z.number().optional(),
       cursor: z.number().optional(),
       limit: z.number(),
     }))
     .query(async ({ input }) => {
       const { chainId, user, limit } = input;
+      const voter = input.voter ?? user;
       const start = input.cursor ?? input.start ?? 0;
       console.log('GET ALL')
       // Generate cache key for this query
@@ -424,7 +427,7 @@ export const hotdogRouter = createTRPCRouter({
             chain: SUPPORTED_CHAINS.find(chain => chain.id === chainId)!,
           }),
         }),
-        isZeroAddress(user)
+        isZeroAddress(voter)
           ? Promise.resolve([[], []] as [bigint[], boolean[]])
           : getUserAttestationsWithChoices({
               contract: getContract({
@@ -432,7 +435,7 @@ export const hotdogRouter = createTRPCRouter({
                 client,
                 chain: SUPPORTED_CHAINS.find(chain => chain.id === chainId)!,
               }),
-              user,
+              user: voter,
             })
       ]);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When you've already voted on a dog, the card now immediately shows your verdict (VALID or SUS) on the homepage and anywhere else `HotdogCard` is rendered — no need to tap the buttons again to discover what you picked.

## Problem

The homepage feed called `getAll` with `ZERO_ADDRESS`, so per-user attestation state was always `false`. `VoteBar` tried to recover via `getUserVotes` (DB index), but that could lag behind on-chain state or miss the wallet address. Users only saw their locked vote after tapping again (which hit the "already attested" path and refreshed state).

## Solution

- **`getAll` API**: add optional `voter` param to fetch on-chain attestation state without filtering the feed by eater
- **Homepage + judges page**: pass the logged-in wallet/session address as `voter`
- **`VoteBar`**: resolve voter from wallet or session, sync highlighted/locked UI when server props or indexed votes load, and set optimistic state on "already attested"
- **Profile page**: load `getUserVotes` and pass real vote state to cards instead of hardcoding `false`

## Testing

- `SKIP_ENV_VALIDATION=true bun run build` — TypeScript + ESLint pass (page-data step fails locally without Thirdweb secrets; pre-existing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f14c1-f7f3-7211-84b0-f7e4460cb986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f14c1-f7f3-7211-84b0-f7e4460cb986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

