### PR TITLE
Fix Farcaster mini-app re-prompting for sign-in on every open

### DIFF
--- a/src/components/utils/Connect.tsx
+++ b/src/components/utils/Connect.tsx
@@ -28,12 +28,24 @@ export const Connect: FC<Props> = ({ loginBtnLabel, className }) => {
   const activeWallet = useActiveWallet();
   const sessionDataRef = useRef<typeof sessionData>(null);
   const statusRef = useRef<typeof status>("loading");
+  const signInInFlightRef = useRef(false);
 
   // Update refs when session data changes
   useEffect(() => {
     sessionDataRef.current = sessionData;
     statusRef.current = status;
   }, [sessionData, status]);
+
+  const hasMatchingSession = useCallback(() => {
+    const sessionAddress = sessionDataRef.current?.user?.address?.toLowerCase();
+    const accountAddress = account?.address?.toLowerCase();
+    return Boolean(
+      sessionDataRef.current?.user?.id &&
+        sessionAddress &&
+        accountAddress &&
+        sessionAddress === accountAddress,
+    );
+  }, [account?.address]);
 
   const cryptoWallets = [
     createWallet("io.metamask"),
@@ -78,7 +90,8 @@ export const Connect: FC<Props> = ({ loginBtnLabel, className }) => {
       // Check session state using refs to avoid dependency issues
       if (
         (sessionDataRef.current?.user?.id ?? false) ||
-        statusRef.current === "loading"
+        statusRef.current === "loading" ||
+        signInInFlightRef.current
       ) {
         return;
       }
@@ -99,6 +112,7 @@ export const Connect: FC<Props> = ({ loginBtnLabel, className }) => {
       if (skipIds.some(id => wallet.id.startsWith(id))) {
         return;
       }
+      signInInFlightRef.current = true;
       try {
         const walletAddress = wallet.getAccount()!.address;
         const payload = await createPayload({ address: walletAddress });
@@ -114,6 +128,8 @@ export const Connect: FC<Props> = ({ loginBtnLabel, className }) => {
         });
       } catch (error) {
         console.error("Error signing in with wallet:", error);
+      } finally {
+        signInInFlightRef.current = false;
       }
     },
     [createPayload, message],
@@ -122,10 +138,11 @@ export const Connect: FC<Props> = ({ loginBtnLabel, className }) => {
   // Auto-sign-in via next-auth when a wallet is already connected but no
   // next-auth session exists yet (e.g. Farcaster mini-app auto-connect).
   useEffect(() => {
-    if (account && activeWallet && !sessionData?.user?.id && status !== "loading") {
-      void silentlySignIn(activeWallet);
+    if (!account || !activeWallet || status === "loading" || hasMatchingSession()) {
+      return;
     }
-  }, [account, activeWallet, sessionData?.user?.id, status, silentlySignIn]);
+    void silentlySignIn(activeWallet);
+  }, [account, activeWallet, sessionData?.user?.id, sessionData?.user?.address, status, silentlySignIn, hasMatchingSession]);
 
   // Prevent hydration mismatch by not rendering ConnectButton until mounted
   if (!mounted) {

--- a/src/providers/Farcaster.tsx
+++ b/src/providers/Farcaster.tsx
@@ -15,9 +15,6 @@ import type {
   FrameNotificationDetails,
 } from "@farcaster/frame-sdk";
 import { useConnect } from "thirdweb/react";
-import { type Wallet } from "thirdweb/wallets";
-import { signMessage } from "thirdweb/utils";
-import { signIn, getCsrfToken, useSession } from "next-auth/react";
 import { DEFAULT_CHAIN } from "~/constants";
 import { toast } from "react-toastify";
 import { getFarcasterSdk } from "~/utils/farcasterSdk";
@@ -64,12 +61,10 @@ export const FarcasterProvider = ({
   const [isMiniApp, setIsMiniApp] = useState(false);
   const [hasConnectedWallet, setHasConnectedWallet] = useState(false);
   const { connect } = useConnect();
-  const { data: sessionData } = useSession();
 
   const connectWallet = useCallback(async () => {
     try {
       const sdk = await getFarcasterSdk();
-      let connectedWallet: Wallet | null = null;
       await connect(async () => {
         // create a wallet instance from the Warpcast provider
         const wallet = EIP1193.fromProvider({
@@ -78,35 +73,18 @@ export const FarcasterProvider = ({
 
         // trigger the connection
         await wallet.connect({ client, chain: DEFAULT_CHAIN });
-        connectedWallet = wallet;
 
         // return the wallet to the app context
         return wallet;
       });
 
-      // Establish a next-auth session immediately after wallet connects.
-      // ConnectButton's onConnect fires only for UI-driven connects — this
-      // auto-connect bypasses it, so we do the SIWE flow here instead.
-      if (connectedWallet && !sessionData?.user?.id) {
-        const account = (connectedWallet as Wallet).getAccount();
-        if (account) {
-          const nonce = await getCsrfToken();
-          if (nonce) {
-            const message = "Sign into Log a Dog";
-            const signature = await signMessage({ message, account });
-            await signIn("ethereum", {
-              message,
-              signature,
-              address: account.address,
-              redirect: false,
-            });
-          }
-        }
-      }
+      // Session sign-in is handled by Connect.tsx once NextAuth has finished
+      // loading the existing session cookie — signing here raced ahead of that
+      // check and prompted for a new signature on every mini-app open.
     } catch (err) {
       console.error("Failed to connect wallet", err);
     }
-  }, [connect, sessionData?.user?.id]);
+  }, [connect]);
 
   const viewProfile = useCallback(async (fid: number) => {
     try {

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -57,6 +57,8 @@ declare module "next-auth/jwt" {
 export const authOptions: NextAuthOptions = {
   session: {
     strategy: "jwt",
+    // Keep users signed in across mini-app opens without re-prompting for SIWE.
+    maxAge: 30 * 24 * 60 * 60,
   },
   callbacks: {
     async jwt({ token, user }) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When opening the app in the Farcaster mini-app, the wallet auto-connects (good), but users were prompted to sign a SIWE message every time — even if they had signed in recently and still had a valid session.

## Root cause

`FarcasterProvider` was establishing a NextAuth session immediately after auto-connecting the wallet, **before** NextAuth finished loading the existing session cookie. On every mini-app open:

1. Wallet auto-connects
2. `sessionData` is still `undefined` (status: `loading`)
3. Provider sees "no session" and triggers a new signature
4. Session cookie loads a moment later — too late

This duplicated the sign-in logic already in `Connect.tsx`, which correctly waits for session status.

## Fix

- **FarcasterProvider**: wallet auto-connect only; no SIWE/sign-in
- **Connect.tsx**: sole handler for silent sign-in after session is loaded
  - Skip when session already matches the connected wallet address
  - Guard against concurrent duplicate sign-in attempts
- **auth.ts**: explicit 30-day session `maxAge` (NextAuth default, now documented)

## Expected behavior

- **Returning user with valid session**: wallet auto-connects, no signature prompt
- **New user or expired session**: wallet auto-connects, one signature prompt to establish session
- Session persists for 30 days via NextAuth JWT cookie
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f14c2-dacb-77e1-8cb3-aece6cb5addd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f14c2-dacb-77e1-8cb3-aece6cb5addd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

