### PR TITLE
Fix Farcaster mini app homepage share image

### DIFF
--- a/public/.well-known/farcaster.json
+++ b/public/.well-known/farcaster.json
@@ -5,7 +5,7 @@
       "version": "1",
       "iconUrl": "https://logadog.xyz/images/logo.png",
       "homeUrl": "https://logadog.xyz",
-      "imageUrl": "https://logadog.xyz/images/logo.png",
+      "imageUrl": "https://www.logadog.xyz/api/og/home",
       "buttonTitle": "Log a Dog",
       "splashImageUrl": "https://www.logadog.xyz/images/logo.png",
       "splashBackgroundColor": "#faf8f7",

--- a/src/components/MiniAppMeta.tsx
+++ b/src/components/MiniAppMeta.tsx
@@ -1,0 +1,16 @@
+import Head from "next/head";
+import {
+  type MiniAppEmbedMetadata,
+  toFrameEmbedMetadata,
+} from "~/constants/miniapp";
+
+export function MiniAppMeta({ metadata }: { metadata: MiniAppEmbedMetadata }) {
+  const frameMetadata = toFrameEmbedMetadata(metadata);
+
+  return (
+    <Head>
+      <meta name="fc:miniapp" content={JSON.stringify(metadata)} />
+      <meta name="fc:frame" content={JSON.stringify(frameMetadata)} />
+    </Head>
+  );
+}

--- a/src/constants/miniapp.ts
+++ b/src/constants/miniapp.ts
@@ -1,0 +1,63 @@
+// Farcaster embeds require absolute URLs on the canonical www host (apex 308s to www).
+const APP_URL = "https://www.logadog.xyz";
+
+export const MINIAPP_SPLASH_IMAGE_URL = `${APP_URL}/images/logo.png`;
+export const MINIAPP_SPLASH_BACKGROUND_COLOR = "#faf8f7";
+export const MINIAPP_HOME_IMAGE_URL = `${APP_URL}/api/og/home`;
+
+export type MiniAppEmbedMetadata = {
+  version: "1";
+  imageUrl: string;
+  button: {
+    title: string;
+    action: {
+      type: "launch_miniapp" | "launch_frame";
+      name: string;
+      url: string;
+      splashImageUrl: string;
+      splashBackgroundColor: string;
+    };
+  };
+};
+
+export function buildMiniAppEmbedMetadata({
+  imageUrl,
+  launchUrl,
+  buttonTitle = "🌭 Log a Dog",
+  appName = "Log a Dog",
+}: {
+  imageUrl: string;
+  launchUrl: string;
+  buttonTitle?: string;
+  appName?: string;
+}): MiniAppEmbedMetadata {
+  return {
+    version: "1",
+    imageUrl,
+    button: {
+      title: buttonTitle,
+      action: {
+        type: "launch_miniapp",
+        name: appName,
+        url: launchUrl,
+        splashImageUrl: MINIAPP_SPLASH_IMAGE_URL,
+        splashBackgroundColor: MINIAPP_SPLASH_BACKGROUND_COLOR,
+      },
+    },
+  };
+}
+
+export function toFrameEmbedMetadata(
+  metadata: MiniAppEmbedMetadata,
+): MiniAppEmbedMetadata {
+  return {
+    ...metadata,
+    button: {
+      ...metadata.button,
+      action: {
+        ...metadata.button.action,
+        type: "launch_frame",
+      },
+    },
+  };
+}

--- a/src/pages/api/og/home.tsx
+++ b/src/pages/api/og/home.tsx
@@ -1,0 +1,43 @@
+import { ImageResponse } from "@vercel/og";
+import type { NextRequest } from "next/server";
+
+export const config = {
+  runtime: "edge",
+};
+
+// Farcaster mini-app embeds require a 3:2 image. The static OG asset is 2:1,
+// so this route crops it to 1200x800 for share cards.
+export default function handler(req: NextRequest) {
+  const base = new URL(req.url).origin;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "1200px",
+          height: "800px",
+          display: "flex",
+          position: "relative",
+        }}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={`${base}/images/og-image.png`}
+          alt="Log a Dog"
+          style={{
+            objectFit: "cover",
+            width: "1200px",
+            height: "800px",
+          }}
+        />
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 800,
+      headers: {
+        "Cache-Control": "public, immutable, no-transform, max-age=86400",
+      },
+    },
+  );
+}

--- a/src/pages/dog/DogPageComponent.tsx
+++ b/src/pages/dog/DogPageComponent.tsx
@@ -1,5 +1,4 @@
 import { type NextPage } from "next";
-import Head from "next/head";
 import { useActiveAccount } from "thirdweb/react";
 import { api } from "~/utils/api";
 import { ZERO_ADDRESS } from "thirdweb";
@@ -9,21 +8,6 @@ import { DEFAULT_CHAIN } from "~/constants";
 const DogPage: NextPage<{ logId: string }> = ({ logId }) => {
   const account = useActiveAccount();
 
-  const miniAppMetadata = {
-    version: "next",
-    imageUrl: `https://logadog.xyz/api/og/${logId}`,
-    button: {
-      title: "🌭 Log a Dog",
-      action: {
-        type: "launch_frame",
-        name: "Log a Dog",
-        url: `https://logadog.xyz/dog/${logId}`,
-        splashImageUrl: "https://logadog.xyz/images/logo.png",
-        splashBackgroundColor: "#faf8f7",
-      },
-    },
-  };
-
   const { data, isLoading, refetch } = api.hotdog.getById.useQuery({
     chainId: DEFAULT_CHAIN.id,
     user: account?.address ?? ZERO_ADDRESS,
@@ -32,25 +16,16 @@ const DogPage: NextPage<{ logId: string }> = ({ logId }) => {
 
   if (isLoading || !data) {
     return (
-      <>
-        <Head>
-          <meta name="fc:frame" content={JSON.stringify(miniAppMetadata)} />
-        </Head>
-        <main className="flex flex-col items-center justify-center">
+      <main className="flex flex-col items-center justify-center">
           <div className="pop-card w-64 h-64 bg-base-300 animate-pulse rounded-2xl" />
-        </main>
-      </>
+      </main>
     );
   }
 
   const { hotdog, validAttestations, invalidAttestations, userAttested, userAttestation } = data;
 
   return (
-    <>
-      <Head>
-        <meta name="fc:frame" content={JSON.stringify(miniAppMetadata)} />
-      </Head>
-      <main className="flex flex-col items-center px-4 py-8">
+    <main className="flex flex-col items-center px-4 py-8">
         <div className="w-full max-w-xl">
           <HotdogCard
             hotdog={hotdog}
@@ -66,7 +41,6 @@ const DogPage: NextPage<{ logId: string }> = ({ logId }) => {
           />
         </div>
       </main>
-    </>
   );
 };
 

--- a/src/pages/dog/[logId].tsx
+++ b/src/pages/dog/[logId].tsx
@@ -1,6 +1,7 @@
 import { type GetServerSideProps, type NextPage } from 'next';
 import dynamic from 'next/dynamic';
-import Head from "next/head";
+import { MiniAppMeta } from "~/components/MiniAppMeta";
+import { buildMiniAppEmbedMetadata } from "~/constants/miniapp";
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { logId } = context.params as { logId: string };
@@ -10,26 +11,14 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 const DogPageComponent = dynamic(() => import('./DogPageComponent'), { ssr: false });
 
 const DogPage: NextPage<{ logId: string }> = ({ logId }) => {
-  const miniAppMetadata = {
-    version: "next",
-    imageUrl: `https://logadog.xyz/api/og/${logId}`,
-    button: {
-      title: "🌭 Log a Dog",
-      action: {
-        type: "launch_frame",
-        name: "Log a Dog",
-        url: `https://logadog.xyz/dog/${logId}`,
-        splashImageUrl: "https://logadog.xyz/images/logo.png",
-        splashBackgroundColor: "#faf8f7",
-      },
-    },
-  };
+  const miniAppMetadata = buildMiniAppEmbedMetadata({
+    imageUrl: `https://www.logadog.xyz/api/og/${logId}`,
+    launchUrl: `https://www.logadog.xyz/dog/${logId}`,
+  });
 
   return (
     <>
-      <Head>
-        <meta name="fc:frame" content={JSON.stringify(miniAppMetadata)} />
-      </Head>
+      <MiniAppMeta metadata={miniAppMetadata} />
       <DogPageComponent logId={logId} />
     </>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,20 +1,15 @@
 import Head from "next/head";
 import { ListAttestations } from "~/components/Attestation/List";
+import { MiniAppMeta } from "~/components/MiniAppMeta";
+import {
+  buildMiniAppEmbedMetadata,
+  MINIAPP_HOME_IMAGE_URL,
+} from "~/constants/miniapp";
 
-const miniAppMetadata = {
-  version: "next",
-  imageUrl: "https://logadog.xyz/images/og-image.png",
-  button: {
-    title: "🌭 Log a Dog",
-    action: {
-      type: "launch_frame",
-      name: "Log a Dog",
-      url: `https://logadog.xyz`,
-      splashImageUrl: "https://logadog.xyz/images/logo.png",
-      splashBackgroundColor: "#faf8f7",
-    },
-  },
-};
+const miniAppMetadata = buildMiniAppEmbedMetadata({
+  imageUrl: MINIAPP_HOME_IMAGE_URL,
+  launchUrl: "https://www.logadog.xyz",
+});
 
 // This generates the page at build time with ISR (recommended for better performance)
 export const getStaticProps = async () => {
@@ -28,13 +23,13 @@ export const getStaticProps = async () => {
 export default function Home() {
   return (
     <>
+      <MiniAppMeta metadata={miniAppMetadata} />
       <Head>
         <title>Log a Dog — the internet&apos;s summer hotdog-eating sport</title>
         <meta
           name="description"
           content="The internet's summer hotdog-eating sport. Log a dog, get judged, climb the board."
         />
-        <meta name="fc:frame" content={JSON.stringify(miniAppMetadata)} />
         <link rel="icon" href="/favicon.ico" />
       </Head>
       {/* Feed-first: the first paint is a dog, not a press release. */}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When sharing the Log a Dog homepage on Farcaster, the link rendered as a mini app but showed the logo instead of the OG artwork.

**Root cause:** Farcaster mini app embeds require a **3:2** `imageUrl` and the primary `fc:miniapp` meta tag. The homepage only had an `fc:frame` tag pointing at `/images/og-image.png`, which is **2:1** (6912×3456). Invalid embed images fall back to the manifest default (`logo.png`).

## Changes

- Add `/api/og/home` — serves a 1200×800 (3:2) crop of the existing OG artwork for Farcaster share cards
- Add `fc:miniapp` meta tag (with `fc:frame` kept for backward compatibility), using spec version `"1"` and `launch_miniapp` action type
- Centralize embed metadata in `src/constants/miniapp.ts` and `MiniAppMeta` component
- Update `farcaster.json` fallback `imageUrl` to the new embed endpoint
- Align dog page embed metadata with the same spec-compliant format

## Testing

- `SKIP_ENV_VALIDATION=true bun run build` — TypeScript compile and lint pass (page data collection fails locally due to missing Thirdweb env vars, pre-existing)

## Post-deploy

After deploy, re-share `https://www.logadog.xyz` on Farcaster. Cached embeds may take time to refresh; you can also use Warpcast's embed debugger if needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f14c6-2ef0-7437-aabf-ee23de81f045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f14c6-2ef0-7437-aabf-ee23de81f045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

