### PR TITLE
Filter judges page to dogs awaiting the user's vote

### DIFF
--- a/mobile/app/(tabs)/judge.tsx
+++ b/mobile/app/(tabs)/judge.tsx
@@ -1,9 +1,10 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { ActivityIndicator, Pressable, Text, View, useWindowDimensions } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Image } from "expo-image";
 import { trpc } from "~/utils/trpc";
 import { CHAIN_ID, ZERO_ADDRESS } from "~/constants";
+import { useAuth } from "~/providers/AuthProvider";
 import { VoteBar } from "~/components/VoteBar";
 import { VerdictStamp } from "~/components/VerdictStamp";
 import { ProfileAvatar } from "~/components/ProfileAvatar";
@@ -21,26 +22,45 @@ const PAGE_SIZE = 20;
 export default function JudgeScreen() {
   const [currentIdx, setCurrentIdx] = useState(0);
   const { width } = useWindowDimensions();
+  const { session } = useAuth();
+  const voterAddress = session?.address;
 
   const query = trpc.hotdog.getAll.useQuery(
     {
       chainId: CHAIN_ID,
       user: ZERO_ADDRESS,
+      voter: voterAddress ?? ZERO_ADDRESS,
       start: 0,
       limit: PAGE_SIZE,
     },
     { staleTime: 60_000 },
   );
 
-  const pending = ((query.data?.hotdogs ?? []) as ProcessedHotdog[]).filter(
-    (h) =>
-      h.attestationPeriod &&
-      h.attestationPeriod.status === 0 &&
-      isInAttestationWindow(
-        h.attestationPeriod.startTime,
-        h.attestationPeriod.endTime,
-      ),
+  const { data: userVotes } = trpc.hotdog.getUserVotes.useQuery(
+    { voter: voterAddress ?? "" },
+    { enabled: !!voterAddress, staleTime: 60_000 },
   );
+
+  const pending = useMemo(() => {
+    const hotdogs = (query.data?.hotdogs ?? []) as ProcessedHotdog[];
+    const userAttested = query.data?.userAttested ?? [];
+    return hotdogs
+      .map((h, i) => ({ h, i }))
+      .filter(({ h, i }) => {
+        const inWindow =
+          h.attestationPeriod &&
+          h.attestationPeriod.status === 0 &&
+          isInAttestationWindow(
+            h.attestationPeriod.startTime,
+            h.attestationPeriod.endTime,
+          );
+        const alreadyVoted =
+          voterAddress &&
+          ((userAttested[i] ?? false) || userVotes?.[h.logId] !== undefined);
+        return inWindow && !alreadyVoted;
+      })
+      .map(({ h }) => h);
+  }, [query.data?.hotdogs, query.data?.userAttested, userVotes, voterAddress]);
 
   const validCounts = query.data?.validAttestations ?? [];
   const invalidCounts = query.data?.invalidAttestations ?? [];

--- a/src/pages/judges.tsx
+++ b/src/pages/judges.tsx
@@ -34,17 +34,25 @@ const JudgesPage: NextPage = () => {
     retry: 1,
   });
 
-  // Dogs still inside their 48h voting window and not yet resolved.
+  const { data: userVotes } = api.hotdog.getUserVotes.useQuery(
+    { voter: voterAddress ?? "" },
+    { enabled: !!voterAddress, refetchOnWindowFocus: false, retry: 1 },
+  );
+
+  // Dogs still inside their 48h voting window, not yet resolved, and awaiting this user's vote.
   const queue = useMemo(() => {
     const hotdogs = dogData?.hotdogs ?? [];
     return hotdogs
       .map((h, i) => ({ h, i }))
-      .filter(({ h }) => {
+      .filter(({ h, i }) => {
         const open = Number(h.timestamp) * 1000 + ATTESTATION_WINDOW_SECONDS * 1000 > Date.now();
         const unresolved = h.attestationPeriod?.status !== 1;
-        return open && unresolved;
+        const alreadyVoted =
+          voterAddress &&
+          ((dogData?.userAttested?.[i] ?? false) || userVotes?.[h.logId] !== undefined);
+        return open && unresolved && !alreadyVoted;
       });
-  }, [dogData?.hotdogs]);
+  }, [dogData?.hotdogs, dogData?.userAttested, userVotes, voterAddress]);
 
   const [cursor, setCursor] = useState(0);
   const current = queue[Math.min(cursor, queue.length - 1)];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The judges page previously showed every dog still inside its 48-hour voting window, including dogs the current user had already voted on. This change filters the jury queue so users only see dogs that still need their verdict.

## Changes

- **`src/pages/judges.tsx`**: Fetches the user's indexed votes via `getUserVotes` and excludes dogs where the user has already attested (checked against both `userAttested` from `getAll` and indexed votes).
- **`mobile/app/(tabs)/judge.tsx`**: Same filtering logic for the mobile judge tab, using the session address as the voter.

## Behavior

- Dogs still being voted on by others remain hidden once **you** have cast your vote.
- Logged-out users still see all open dogs (they cannot vote without signing in).
- After voting, the dog drops out of the queue on refetch because `VoteBar` already invalidates `getUserVotes`.

## Test plan

- [ ] Sign in and visit `/judges` — only dogs you haven't voted on appear in the queue.
- [ ] Cast a vote — the dog should disappear from the queue after the refetch.
- [ ] Visit `/judges` when you've voted on all open dogs — see the empty-state message.
- [ ] Use "Skip to next dog" — only skips among dogs you haven't voted on yet.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f14d7-4e1b-7f59-ba98-9ebad8a20c79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f14d7-4e1b-7f59-ba98-9ebad8a20c79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

