### PR TITLE
Fix invalid Farcaster domain manifest JSON

### DIFF
--- a/public/.well-known/farcaster.json
+++ b/public/.well-known/farcaster.json
@@ -1,37 +1,40 @@
-
 {
-    "frame": {
-      "name": "Log a Dog",
-      "version": "1",
-      "iconUrl": "https://logadog.xyz/images/logo.png",
-      "homeUrl": "https://logadog.xyz",
-      "imageUrl": "https://www.logadog.xyz/api/og/home",
-      "buttonTitle": "Log a Dog",
-      "splashImageUrl": "https://www.logadog.xyz/images/logo.png",
-      "splashBackgroundColor": "#faf8f7",
-      "webhookUrl": "https://api.neynar.com/f/app/0e9ca0e4-2b23-4927-b049-6698f3615914/event",
-      "subtitle": "Onchain hotdog eating contest",
-      "description": "Upload a pic of you eating a hotdog and earn onchain",
-      "primaryCategory": "social",
-      "heroImageUrl": "https://www.logadog.xyz/images/og-image.png",
-      "tags": [
-        "summer",
-        "food",
-        "hotdog",
-        "contest",
-        "eating"
-      ],
-      "tagline": "Log dogs, earn money",
-      "ogTitle": "Log a Dog",
-      "ogDescription": "Earn money competing in the internet's hotdog eating contest",
-      "ogImageUrl": "https://www.logadog.xyz/images/og-image.png"
-    },
-    "accountAssociation": {
-      "header": "eyJmaWQiOjIxNzI0OCwidHlwZSI6ImN1c3RvZHkiLCJrZXkiOiIweGViYTc4NzE3YjZmMDU5Q0ZFMGI3NUU3NUMyZWQ0QkI3Y0E2NTE1NEYifQ",
-      "payload": "eyJkb21haW4iOiJsb2dhZG9nLnh5eiJ9",
-      "signature": "MHgyN2JmMjY5OTU2MzI1OWJkNzA3OTgzMmE3MWU5M2RjMjcwZTA1MzUwNjcwZTY3MGZlN2JlNzExNTU5YzM5YmZlMjg4YmIwMmFjNjgwZmQ2ZTQ0ZWM3NTFjYmE5ZWFlOWI3NWViNmM3MDY5ZmMyZDBjYjEzOTFkZjgyODgwMjU4ODFi"
-    },
-    "baseBuilder": {
-        "allowedAddresses": ["0x515B4Ff55078066BA8B025a1e974215084FE86d5", "0x9BfA5bFD4041B83D8681300913Db59329b8Eac14", "0xe491d0F909DE0B8C3ae89db1Acb391Ef756F0da5"],
-    }
+  "accountAssociation": {
+    "header": "eyJmaWQiOjIxNzI0OCwidHlwZSI6ImN1c3RvZHkiLCJrZXkiOiIweGViYTc4NzE3YjZmMDU5Q0ZFMGI3NUU3NUMyZWQ0QkI3Y0E2NTE1NEYifQ",
+    "payload": "eyJkb21haW4iOiJsb2dhZG9nLnh5eiJ9",
+    "signature": "MHgyN2JmMjY5OTU2MzI1OWJkNzA3OTgzMmE3MWU5M2RjMjcwZTA1MzUwNjcwZTY3MGZlN2JlNzExNTU5YzM5YmZlMjg4YmIwMmFjNjgwZmQ2ZTQ0ZWM3NTFjYmE5ZWFlOWI3NWViNmM3MDY5ZmMyZDBjYjEzOTFkZjgyODgwMjU4ODFi"
+  },
+  "frame": {
+    "name": "Log a Dog",
+    "version": "1",
+    "iconUrl": "https://logadog.xyz/images/logo.png",
+    "homeUrl": "https://logadog.xyz",
+    "imageUrl": "https://www.logadog.xyz/api/og/home",
+    "buttonTitle": "Log a Dog",
+    "splashImageUrl": "https://www.logadog.xyz/images/logo.png",
+    "splashBackgroundColor": "#faf8f7",
+    "webhookUrl": "https://api.neynar.com/f/app/0e9ca0e4-2b23-4927-b049-6698f3615914/event",
+    "subtitle": "Onchain hotdog eating contest",
+    "description": "Upload a pic of you eating a hotdog and earn onchain",
+    "primaryCategory": "social",
+    "heroImageUrl": "https://www.logadog.xyz/images/og-image.png",
+    "tags": [
+      "summer",
+      "food",
+      "hotdog",
+      "contest",
+      "eating"
+    ],
+    "tagline": "Log dogs, earn money",
+    "ogTitle": "Log a Dog",
+    "ogDescription": "Earn money competing in the internet's hotdog eating contest",
+    "ogImageUrl": "https://www.logadog.xyz/images/og-image.png"
+  },
+  "baseBuilder": {
+    "allowedAddresses": [
+      "0x515B4Ff55078066BA8B025a1e974215084FE86d5",
+      "0x9BfA5bFD4041B83D8681300913Db59329b8Eac14",
+      "0xe491d0F909DE0B8C3ae89db1Acb391Ef756F0da5"
+    ]
   }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+const APEX_HOST = "logadog.xyz";
+const CANONICAL_HOST = "www.logadog.xyz";
+
+export function middleware(request: NextRequest) {
+  const host = request.headers.get("host")?.split(":")[0] ?? "";
+  const { pathname } = request.nextUrl;
+
+  if (host === APEX_HOST && !pathname.startsWith("/.well-known/")) {
+    const url = request.nextUrl.clone();
+    url.host = CANONICAL_HOST;
+    url.protocol = "https:";
+    return NextResponse.redirect(url, 308);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Domain manifest verification for `logadog.xyz` fails with:

```
Expected object, received string
```

## Root cause

`public/.well-known/farcaster.json` contained **invalid JSON** — a trailing comma after the `baseBuilder.allowedAddresses` array (introduced in #522971b). When Farcaster's validator cannot parse the response as JSON, it treats the raw body as a string and Zod reports the error above.

## Fix

- Remove the trailing comma and normalize the manifest as valid JSON
- Reorder fields to put `accountAssociation` first (per Farcaster spec)
- Add `src/middleware.ts` to redirect `logadog.xyz` → `www.logadog.xyz` for all paths **except** `/.well-known/*`

## Post-deploy step (if apex verification still fails)

Vercel currently applies a platform-level 308 redirect from `logadog.xyz` → `www.logadog.xyz` **before** the app runs, including for `/.well-known/farcaster.json`. That returns `Redirecting...` instead of the manifest.

To serve the manifest on the apex domain (required because `accountAssociation` is signed for `logadog.xyz`):

1. In Vercel → Project → Domains, **disable** the automatic redirect from `logadog.xyz` to `www.logadog.xyz`
2. The new middleware will continue redirecting all other apex traffic to `www`

After deploy, re-check verification in the Farcaster Domains tool.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f14df-f2d0-71e1-a03c-bca6d3ad8fad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f14df-f2d0-71e1-a03c-bca6d3ad8fad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

