### PR TITLE
Use openMiniApp for POIDH links in Farcaster mini app

### DIFF
--- a/src/pages/poidh.tsx
+++ b/src/pages/poidh.tsx
@@ -1,6 +1,7 @@
 import { type NextPage } from "next";
 import Head from "next/head";
 import Link from "next/link";
+import { useCallback, useContext } from "react";
 import {
   CameraIcon,
   ShareIcon,
@@ -8,6 +9,8 @@ import {
   CheckCircleIcon,
   StarIcon,
 } from "@heroicons/react/24/outline";
+import { FarcasterContext } from "~/providers/Farcaster";
+import { openMiniApp } from "~/utils/farcasterSdk";
 
 const POIDH_BOUNTY_URL = "https://poidh.xyz/base/bounty/1265";
 
@@ -52,6 +55,24 @@ const WINNING_CRITERIA = [
 ];
 
 const PoidhPage: NextPage = () => {
+  const farcaster = useContext(FarcasterContext);
+  const isMiniApp = farcaster?.isMiniApp ?? false;
+
+  const openPoidh = useCallback(
+    async (e: React.MouseEvent<HTMLAnchorElement>) => {
+      if (!isMiniApp) return;
+
+      e.preventDefault();
+      try {
+        await openMiniApp(POIDH_BOUNTY_URL);
+      } catch (err) {
+        console.error("Failed to open POIDH mini app", err);
+        window.open(POIDH_BOUNTY_URL, "_blank");
+      }
+    },
+    [isMiniApp],
+  );
+
   return (
     <>
       <Head>
@@ -89,8 +110,9 @@ const PoidhPage: NextPage = () => {
                 <p className="mt-1 text-sm opacity-80">One winner picked per day by the organizers.</p>
                 <a
                   href={POIDH_BOUNTY_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                  target={isMiniApp ? undefined : "_blank"}
+                  rel={isMiniApp ? undefined : "noopener noreferrer"}
+                  onClick={openPoidh}
                   className="mt-2 inline-block text-sm font-semibold underline underline-offset-2 opacity-90 hover:opacity-100"
                 >
                   View bounty on POIDH →
@@ -217,8 +239,9 @@ const PoidhPage: NextPage = () => {
             </Link>
             <a
               href={POIDH_BOUNTY_URL}
-              target="_blank"
-              rel="noopener noreferrer"
+              target={isMiniApp ? undefined : "_blank"}
+              rel={isMiniApp ? undefined : "noopener noreferrer"}
+              onClick={openPoidh}
               className="pop-btn flex items-center justify-center gap-2 rounded-2xl border-[3px] border-base-content bg-base-100 px-5 py-4 font-display tracking-wide"
             >
               <CurrencyDollarIcon className="h-5 w-5" />

--- a/src/utils/farcasterSdk.ts
+++ b/src/utils/farcasterSdk.ts
@@ -2,3 +2,19 @@ export const getFarcasterSdk = async () => {
   const { sdk } = await import("@farcaster/frame-sdk");
   return sdk;
 };
+
+type OpenMiniAppAction = (options: { url: string }) => Promise<void>;
+
+export const openMiniApp = async (url: string) => {
+  const sdk = await getFarcasterSdk();
+  const actions = sdk.actions as typeof sdk.actions & {
+    openMiniApp?: OpenMiniAppAction;
+  };
+
+  if (actions.openMiniApp) {
+    await actions.openMiniApp({ url });
+    return;
+  }
+
+  window.open(url, "_blank");
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the `/poidh` campaign page, POIDH bounty links now use the Farcaster Mini App SDK `openMiniApp` action when the user is inside the Log a Dog mini app. This provides seamless navigation to the POIDH mini app instead of opening a new browser tab.

Outside the mini app, links continue to open in a new tab as before.

## Changes

- **`src/pages/poidh.tsx`**: Detect mini app context and intercept both POIDH links ("View bounty on POIDH" and "Submit claim on POIDH") to call `openMiniApp`.
- **`src/utils/farcasterSdk.ts`**: Add a reusable `openMiniApp` helper with a runtime capability check and fallback to `window.open`.

## Behavior

| Context | Action |
|---------|--------|
| Farcaster mini app | `sdk.actions.openMiniApp({ url: POIDH_BOUNTY_URL })` |
| Regular browser | `target="_blank"` link (unchanged) |
| SDK call fails | Falls back to `window.open` |

## Notes

The pinned `@farcaster/frame-sdk@0.0.63` types do not yet include `openMiniApp`, so the helper uses a runtime check against `sdk.actions.openMiniApp` (available in current Farcaster clients per [docs](https://miniapps.farcaster.xyz/docs/sdk/actions/open-miniapp)).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1641-97bb-79ce-9b84-b6a8ee9b8c88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1641-97bb-79ce-9b84-b6a8ee9b8c88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

