### PR TITLE
Fix fallback avatar border radius with thirdweb Blobbie

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
         "react-apexcharts": "^1.9.0",
         "react-dom": "18.2.0",
         "react-dropzone": "^14.4.1",
-        "react-jazzicon": "^1.0.4",
         "react-toastify": "^10.0.6",
         "react-tweet": "^3.3.1",
         "sharp": "^0.33.5",
@@ -17058,12 +17057,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/mersenne-twister": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mersenne-twister/-/mersenne-twister-1.1.0.tgz",
-      "integrity": "sha512-mUYWsMKNrm4lfygPkL3OfGzOPTR2DBlTkBNHM//F6hGp8cLThY897crAlk3/Jo17LEOOjQUrNAx6DvgO77QJkA==",
-      "license": "MIT"
-    },
     "node_modules/micro-ftch": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/micro-ftch/-/micro-ftch-0.3.1.tgz",
@@ -19986,19 +19979,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
-    },
-    "node_modules/react-jazzicon": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/react-jazzicon/-/react-jazzicon-1.0.4.tgz",
-      "integrity": "sha512-/3kWv5vtAhI18GBFoqjpxRTtL+EImuB73PAC02r/zJQ6E+PAUmoBx8edYvTCIYHwS01uFf6N3elTDqSrVPwg4w==",
-      "license": "MIT",
-      "dependencies": {
-        "mersenne-twister": "^1.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=17.0.0",
-        "react-dom": ">=17.0.0"
-      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "react-apexcharts": "^1.9.0",
     "react-dom": "18.2.0",
     "react-dropzone": "^14.4.1",
-    "react-jazzicon": "^1.0.4",
     "react-toastify": "^10.0.6",
     "react-tweet": "^3.3.1",
     "sharp": "^0.33.5",

--- a/src/components/LeaderboardBanner.tsx
+++ b/src/components/LeaderboardBanner.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import styles from "./LeaderboardBanner.module.css";
 import useLeaderboardData from "~/hooks/useLeaderboardData";
 import usePrefersReducedMotion from "~/hooks/usePrefersReducedMotion";
-import Jazzicon, { jsNumberForAddress } from "react-jazzicon";
+import { Blobbie } from "thirdweb/react";
 import { getProxiedUrl } from "~/utils/imageProxy";
 import Image from "next/image";
 
@@ -43,11 +43,7 @@ const TickerPill: FC<{ item: TickerItem }> = ({ item }) => (
         className="h-5 w-5 rounded-full object-cover"
       />
     ) : (
-      <Jazzicon
-        diameter={20}
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-        seed={jsNumberForAddress(item.address)}
-      />
+      <Blobbie address={item.address} size={20} className="shrink-0 rounded-full" />
     )}
     <span className="font-medium">{item.name}</span>
     <Badge

--- a/src/components/LeaderboardList.tsx
+++ b/src/components/LeaderboardList.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { motion } from "motion/react";
 import useLeaderboardData from "~/hooks/useLeaderboardData";
 import { useSession } from "next-auth/react";
-import Jazzicon, { jsNumberForAddress } from "react-jazzicon";
+import { Blobbie } from "thirdweb/react";
 import { getProxiedUrl } from "~/utils/imageProxy";
 import Image from "next/image";
 
@@ -52,8 +52,7 @@ const LbAvatar: FC<{ profile?: ProfileData; address: string; size: number }> = (
     );
   }
   return (
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-    <Jazzicon diameter={size} seed={jsNumberForAddress(address)} />
+    <Blobbie address={address} size={size} className="shrink-0 rounded-full" />
   );
 };
 

--- a/src/components/Profile/Avatar.tsx
+++ b/src/components/Profile/Avatar.tsx
@@ -1,11 +1,17 @@
 import { type FC, memo } from "react";
-import { MediaRenderer } from "thirdweb/react";
+import { Blobbie, MediaRenderer } from "thirdweb/react";
 import { client } from "~/providers/Thirdweb";
 import { api } from "~/utils/api";
-import Jazzicon, { jsNumberForAddress } from "react-jazzicon";
 import { ZERO_ADDRESS } from "thirdweb";
 import { DEFAULT_CHAIN } from "~/constants";
 import { getProxiedUrl } from "~/utils/imageProxy";
+
+function avatarPixelSize(size?: string, fallbackSize?: number): number {
+  if (fallbackSize != null) return fallbackSize;
+  if (!size) return 32;
+  const parsed = Number.parseInt(size, 10);
+  return Number.isFinite(parsed) ? parsed : 32;
+}
 
 const AvatarComponent: FC<{ address: string; fallbackSize?: number; size?: string }> = ({ address, fallbackSize, size }) => {
   const { data: profile, isLoading } = api.profile.getByAddress.useQuery({
@@ -18,6 +24,7 @@ const AvatarComponent: FC<{ address: string; fallbackSize?: number; size?: strin
   });
 
   const dimension = size ?? "32px";
+  const pixelSize = avatarPixelSize(size, fallbackSize);
 
   if (isLoading) {
     return (
@@ -29,26 +36,22 @@ const AvatarComponent: FC<{ address: string; fallbackSize?: number; size?: strin
   }
   if (profile?.imgUrl === "") {
     return (
-      <div className={'mt-1.5'}>
-        <Jazzicon
-          diameter={fallbackSize ?? 16}
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-          seed={jsNumberForAddress(address)}
-        />
-      </div>
+      <Blobbie
+        address={address}
+        size={pixelSize}
+        className="shrink-0 rounded-full"
+      />
     );
   }
 
   if (!profile) {
     return (
-      <div className={'mt-1.5'}>
-        <Jazzicon
-          diameter={fallbackSize ?? 16}
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-          seed={jsNumberForAddress(ZERO_ADDRESS)}
-        />
-      </div>
-    )
+      <Blobbie
+        address={ZERO_ADDRESS}
+        size={pixelSize}
+        className="shrink-0 rounded-full"
+      />
+    );
   }
 
   return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the oval black border around fallback avatars when a user has no profile image set.

## Problem

Jazzicon fallbacks were wrapped in a `mt-1.5` container without explicit square dimensions. Inside `pop-frame` circular borders (e.g. on HotdogCard), this caused the border to render as a vertical oval instead of a flush circle around the avatar.

## Solution

- Replaced `react-jazzicon` with thirdweb's `Blobbie` component, which renders a square div with explicit `size` and supports `rounded-full`
- Removed the `mt-1.5` offset wrapper on fallback avatars
- Unified pixel sizing via `avatarPixelSize()` so `fallbackSize` and `size` props stay consistent
- Updated `LeaderboardList` and `LeaderboardBanner` to use Blobbie as well
- Removed unused `react-jazzicon` dependency

## Files changed

- `src/components/Profile/Avatar.tsx`
- `src/components/LeaderboardList.tsx`
- `src/components/LeaderboardBanner.tsx`
- `package.json` / `package-lock.json`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1dc8-265b-7efe-8d63-6bfb5d28c519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1dc8-265b-7efe-8d63-6bfb5d28c519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

