### PR TITLE
Fix judges ranking to consolidate voters by Farcaster FID

### DIFF
--- a/src/server/api/routers/hotdog.ts
+++ b/src/server/api/routers/hotdog.ts
@@ -27,6 +27,7 @@ import { getAttestationCounts } from "~/thirdweb/84532/0xc470f55c2877848f1acfcf3
 import { getDogEvents, getDogEventsByEater, getDogEventLeaderboard } from "~/server/api/dog-events";
 import { db } from "~/server/db";
 import { buildHotdogProfileMap, fetchUserProfiles } from "~/server/utils/profile";
+import { buildAddressGroups } from "~/server/utils/fid";
 import { getUserOpGasFees } from "thirdweb/wallets/smart";
 import { abi } from "~/constants/abi/logadog";
 
@@ -1307,7 +1308,7 @@ export const hotdogRouter = createTRPCRouter({
     const chainId = DEFAULT_CHAIN.id.toString();
     const contestStartTimestamp = BigInt(Math.floor(new Date(DOG_FEED_START_TIME).getTime() / 1000));
     const contestEndTimestamp = BigInt(Math.floor(new Date(CONTEST_END_TIME).getTime() / 1000));
-    const cacheKey = `judges:ranking:${chainId}:${DOG_FEED_START_TIME}`;
+    const cacheKey = `judges:ranking:v2:${chainId}:${DOG_FEED_START_TIME}`;
 
     return getOrSetCache(
       cacheKey,
@@ -1344,18 +1345,59 @@ export const hotdogRouter = createTRPCRouter({
         const voterAddresses = Object.keys(judgeStats);
         if (voterAddresses.length === 0) return [];
 
-        const profileMap = await fetchUserProfiles(voterAddresses);
+        const addressGroups = await buildAddressGroups(voterAddresses);
+        const addressToGroupKey = new Map<string, string>();
+        for (const group of addressGroups) {
+          for (const addr of group.addresses) {
+            addressToGroupKey.set(addr, group.key);
+          }
+        }
 
-        return Object.entries(judgeStats)
-          .map(([voter, stats]) => ({
-            voter,
-            correct: stats.correct,
-            incorrect: stats.total - stats.correct,
-            total: stats.total,
-            accuracy: stats.total > 0 ? (stats.correct / stats.total) * 100 : 0,
-            profile: profileMap.get(voter) ?? { username: "", imgUrl: "", metadata: "", address: voter },
-          }))
-          .sort((a, b) => b.correct - a.correct);
+        const consolidatedStats = new Map<
+          string,
+          { correct: number; total: number; addresses: string[] }
+        >();
+        for (const [voter, stats] of Object.entries(judgeStats)) {
+          const groupKey = addressToGroupKey.get(voter) ?? `addr:${voter}`;
+          const group = addressGroups.find((g) => g.key === groupKey);
+          const existing = consolidatedStats.get(groupKey);
+          if (existing) {
+            existing.correct += stats.correct;
+            existing.total += stats.total;
+          } else {
+            consolidatedStats.set(groupKey, {
+              correct: stats.correct,
+              total: stats.total,
+              addresses: group?.addresses ?? [voter],
+            });
+          }
+        }
+
+        const profileAddresses = [
+          ...new Set(
+            [...consolidatedStats.values()].flatMap((s) => s.addresses),
+          ),
+        ];
+        const profileMap = await fetchUserProfiles(profileAddresses);
+
+        return [...consolidatedStats.values()]
+          .map((stats) => {
+            const voter = stats.addresses[0] ?? "";
+            return {
+              voter,
+              correct: stats.correct,
+              incorrect: stats.total - stats.correct,
+              total: stats.total,
+              accuracy: stats.total > 0 ? (stats.correct / stats.total) * 100 : 0,
+              profile: profileMap.get(voter) ?? {
+                username: "",
+                imgUrl: "",
+                metadata: "",
+                address: voter,
+              },
+            };
+          })
+          .sort((a, b) => b.correct - a.correct || b.total - a.total);
       },
       CACHE_DURATION.MEDIUM
     );

--- a/src/server/utils/fid.ts
+++ b/src/server/utils/fid.ts
@@ -1,0 +1,79 @@
+import { neynarClient } from "~/lib/neynar";
+import { db } from "~/server/db";
+
+export type AddressGroup = {
+  key: string;
+  fid?: number;
+  addresses: string[];
+};
+
+/** Map wallet addresses to Farcaster FIDs (DB first, then Neynar). */
+export async function getAddressFidMap(
+  addresses: string[],
+): Promise<Map<string, number>> {
+  const unique = [...new Set(addresses.map((a) => a.toLowerCase()))];
+  const addressToFid = new Map<string, number>();
+  if (unique.length === 0) return addressToFid;
+
+  const dbUsers = await db.user.findMany({
+    where: { address: { in: unique } },
+    select: { address: true, fid: true },
+  });
+
+  for (const user of dbUsers) {
+    if (user.address && user.fid) {
+      addressToFid.set(user.address.toLowerCase(), user.fid);
+    }
+  }
+
+  const missingFid = unique.filter((a) => !addressToFid.has(a));
+  if (missingFid.length > 0) {
+    try {
+      const response = await neynarClient.fetchBulkUsersByEthOrSolAddress({
+        addresses: missingFid,
+      });
+      for (const addr of missingFid) {
+        const fid = response[addr]?.[0]?.fid;
+        if (fid) addressToFid.set(addr, fid);
+      }
+    } catch (error) {
+      console.error("Error fetching FIDs from Neynar:", error);
+    }
+  }
+
+  return addressToFid;
+}
+
+/** Group addresses by shared Farcaster FID, or by address when no FID is known. */
+export async function buildAddressGroups(
+  addresses: string[],
+): Promise<AddressGroup[]> {
+  const unique = [...new Set(addresses.map((a) => a.toLowerCase()))];
+  if (unique.length === 0) return [];
+
+  const addressToFid = await getAddressFidMap(unique);
+  const fidToAddresses = new Map<number, Set<string>>();
+
+  for (const [addr, fid] of addressToFid) {
+    if (!fidToAddresses.has(fid)) fidToAddresses.set(fid, new Set());
+    fidToAddresses.get(fid)!.add(addr);
+  }
+
+  const groups = new Map<string, AddressGroup>();
+
+  for (const [fid, addrs] of fidToAddresses) {
+    groups.set(`fid:${fid}`, {
+      key: `fid:${fid}`,
+      fid,
+      addresses: Array.from(addrs),
+    });
+  }
+
+  for (const addr of unique) {
+    if (!addressToFid.has(addr)) {
+      groups.set(`addr:${addr}`, { key: `addr:${addr}`, addresses: [addr] });
+    }
+  }
+
+  return Array.from(groups.values());
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The **Top Judges** list on `/judges` showed the same person multiple times (e.g. "myk.eth" and "Myk" with the same avatar) because rankings were grouped by wallet address only.

The main **Leaderboard** already consolidates users who share a Farcaster FID across multiple linked wallets.

## Solution

- Add `src/server/utils/fid.ts` with shared helpers to resolve FIDs from the DB and Neynar, then group wallet addresses by FID.
- Update `hotdog.getJudges` to aggregate vote counts and accuracy per Farcaster identity instead of per address.
- Bump the Redis cache key to `judges:ranking:v2:…` so stale per-address rankings are invalidated on deploy.

## Result

A judge who voted from multiple linked wallets now appears once with combined vote totals and accuracy, consistent with leaderboard behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1dd9-5156-7d7b-be34-c482805e4e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1dd9-5156-7d7b-be34-c482805e4e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

