### PR TITLE
Expo/web parity: shared data layer, mobile feature parity, typed tRPC + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    name: Typecheck (web + shared + mobile)
+    runs-on: ubuntu-latest
+    env:
+      SKIP_ENV_VALIDATION: "true"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # Installs web deps and generates the Prisma client (postinstall).
+      - name: Install web deps
+        run: bun install
+
+      # Typechecks the web app AND the shared/ data layer (both in tsconfig).
+      - name: Typecheck web + shared
+        run: bun run typecheck
+
+      # Emits the self-contained AppRouter declaration bundle the mobile app
+      # types its tRPC client against (mobile/api-types), then rewrites the
+      # "~" path aliases to relative paths so it resolves standalone.
+      - name: Build mobile API types
+        run: bun run build:api-types
+
+      - name: Install mobile deps
+        working-directory: mobile
+        run: bun install
+
+      # Mobile tsc resolves server-only type packages (e.g. @prisma/client)
+      # referenced by the generated bundle from the root node_modules installed
+      # above via normal upward module resolution.
+      - name: Typecheck mobile
+        working-directory: mobile
+        run: bun run typecheck

--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -29,3 +29,5 @@ android/app/build/
 android/app/debug.keystore
 ios/Pods/
 ios/build/
+# generated tRPC AppRouter declaration bundle (build:api-types)
+api-types/

--- a/mobile/app/(tabs)/earn.tsx
+++ b/mobile/app/(tabs)/earn.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 import { Linking, Pressable, ScrollView, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { useRouter } from "expo-router";
 import { useAuth } from "~/providers/AuthProvider";
-import { API_URL } from "~/constants";
+import { API_URL, CHAIN_ID } from "~/constants";
+import { trpc } from "~/utils/trpc";
+import { getSeasonInfo } from "@shared/season";
 
 interface InfoCardProps {
   icon: string;
@@ -31,6 +34,12 @@ function InfoCard({ icon, title, body, action }: InfoCardProps) {
 
 export default function EarnScreen() {
   const { session } = useAuth();
+  const router = useRouter();
+  const season = getSeasonInfo();
+  const { data: apy } = trpc.staking.getApy.useQuery(
+    { chainId: CHAIN_ID },
+    { refetchOnWindowFocus: false, staleTime: 60_000 },
+  );
 
   const openWebApp = (path: string) => {
     Linking.openURL(`${API_URL}${path}`);
@@ -45,9 +54,37 @@ export default function EarnScreen() {
         <Text className="font-display text-neutral text-2xl mb-1 tracking-wider">
           EARN $HOTDOG
         </Text>
-        <Text className="text-neutral/60 text-sm mb-6">
+        <Text className="text-neutral/60 text-sm mb-4">
           Stake tokens to vote and earn rewards for accurate verdicts.
         </Text>
+
+        {/* Live stats */}
+        <View className="flex-row gap-3 mb-6">
+          <View className="flex-1 bg-accent/10 rounded-2xl p-4">
+            <Text className="text-neutral/50 text-xs mb-1">Staking APY</Text>
+            <Text className="font-display text-accent text-2xl">
+              {typeof apy === "number" ? `${apy.toFixed(1)}%` : "—"}
+            </Text>
+          </View>
+          <View className="flex-1 bg-primary/10 rounded-2xl p-4">
+            <Text className="text-neutral/50 text-xs mb-1">
+              Season {season.season}
+            </Text>
+            <Text className="font-display text-neutral text-2xl">
+              {season.isLive ? `Day ${season.day}` : "Soon"}
+            </Text>
+          </View>
+        </View>
+
+        <Pressable
+          onPress={() => router.push("/faq")}
+          className="mb-6 bg-base-200 rounded-xl px-4 py-3 flex-row items-center justify-between"
+        >
+          <Text className="text-neutral font-bold text-sm">
+            📖 How it works · Rules & FAQ
+          </Text>
+          <Text className="text-neutral/40">→</Text>
+        </Pressable>
 
         <InfoCard
           icon="🌭"

--- a/mobile/app/(tabs)/earn.tsx
+++ b/mobile/app/(tabs)/earn.tsx
@@ -78,10 +78,20 @@ export default function EarnScreen() {
 
         <Pressable
           onPress={() => router.push("/faq")}
-          className="mb-6 bg-base-200 rounded-xl px-4 py-3 flex-row items-center justify-between"
+          className="mb-3 bg-base-200 rounded-xl px-4 py-3 flex-row items-center justify-between"
         >
           <Text className="text-neutral font-bold text-sm">
             📖 How it works · Rules & FAQ
+          </Text>
+          <Text className="text-neutral/40">→</Text>
+        </Pressable>
+
+        <Pressable
+          onPress={() => router.push("/poidh")}
+          className="mb-6 bg-secondary/10 border border-secondary/30 rounded-xl px-4 py-3 flex-row items-center justify-between"
+        >
+          <Text className="text-neutral font-bold text-sm">
+            🕹️ POIDH Campaign · Win $50 ETH/day
           </Text>
           <Text className="text-neutral/40">→</Text>
         </Pressable>

--- a/mobile/app/(tabs)/judge.tsx
+++ b/mobile/app/(tabs)/judge.tsx
@@ -20,25 +20,14 @@ import { ProfileAvatar } from "~/components/ProfileAvatar";
 import { COLORS } from "~/constants/colors";
 import { convertIpfsToHttps, formatTimestamp, getDisplayName } from "~/utils/format";
 import { isJudgeable } from "@shared/time";
+import { useJudges, useUserVotes } from "~/hooks/useHotdogs";
 import type { ProcessedHotdog } from "~/types";
 
 const PAGE_SIZE = 50;
 
-interface Judge {
-  voter: string;
-  correct: number;
-  incorrect: number;
-  total: number;
-  accuracy: number;
-  profile: { username?: string; imgUrl?: string; address?: string };
-}
-
 function TopJudges() {
   const router = useRouter();
-  const { data: judges = [], isLoading } = trpc.hotdog.getJudges.useQuery(
-    undefined,
-    { refetchOnWindowFocus: false, retry: 1 },
-  );
+  const { judges, isLoading } = useJudges();
 
   if (isLoading) {
     return (
@@ -47,7 +36,7 @@ function TopJudges() {
       </View>
     );
   }
-  if ((judges as Judge[]).length === 0) return null;
+  if (judges.length === 0) return null;
 
   return (
     <View className="px-4 pt-2 pb-8">
@@ -55,7 +44,7 @@ function TopJudges() {
         🏅 TOP JUDGES
       </Text>
       <View className="gap-2">
-        {(judges as Judge[]).map((j, idx) => (
+        {judges.map((j, idx) => (
           <Pressable
             key={j.voter}
             onPress={() => router.push(`/profile/address/${j.voter}` as never)}
@@ -109,10 +98,7 @@ export default function JudgeScreen() {
     { staleTime: 60_000 },
   );
 
-  const { data: userVotes } = trpc.hotdog.getUserVotes.useQuery(
-    { voter: voterAddress ?? "" },
-    { enabled: !!voterAddress, staleTime: 60_000 },
-  );
+  const userVotes = useUserVotes(voterAddress);
 
   const allDogs = useMemo(
     () => (query.data?.hotdogs ?? []) as ProcessedHotdog[],

--- a/mobile/app/(tabs)/judge.tsx
+++ b/mobile/app/(tabs)/judge.tsx
@@ -1,23 +1,93 @@
 import React, { useCallback, useMemo, useState } from "react";
-import { ActivityIndicator, Pressable, Text, View, useWindowDimensions } from "react-native";
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+  useWindowDimensions,
+} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Image } from "expo-image";
 import { trpc } from "~/utils/trpc";
 import { CHAIN_ID, ZERO_ADDRESS } from "~/constants";
 import { useAuth } from "~/providers/AuthProvider";
 import { VoteBar } from "~/components/VoteBar";
-import { VerdictStamp } from "~/components/VerdictStamp";
+import { AiJudgement } from "~/components/AiJudgement";
+import { VotingCountdown } from "~/components/VotingCountdown";
 import { ProfileAvatar } from "~/components/ProfileAvatar";
 import { COLORS } from "~/constants/colors";
-import {
-  convertIpfsToHttps,
-  formatTimestamp,
-  getDisplayName,
-  isInAttestationWindow,
-} from "~/utils/format";
+import { convertIpfsToHttps, formatTimestamp, getDisplayName } from "~/utils/format";
+import { isJudgeable } from "@shared/time";
 import type { ProcessedHotdog } from "~/types";
 
-const PAGE_SIZE = 20;
+const PAGE_SIZE = 50;
+
+interface Judge {
+  voter: string;
+  correct: number;
+  incorrect: number;
+  total: number;
+  accuracy: number;
+  profile: { username?: string; imgUrl?: string; address?: string };
+}
+
+function TopJudges() {
+  const { data: judges = [], isLoading } = trpc.hotdog.getJudges.useQuery(
+    undefined,
+    { refetchOnWindowFocus: false, retry: 1 },
+  );
+
+  if (isLoading) {
+    return (
+      <View className="py-6 items-center">
+        <ActivityIndicator color={COLORS.primary} />
+      </View>
+    );
+  }
+  if ((judges as Judge[]).length === 0) return null;
+
+  return (
+    <View className="px-4 pt-2 pb-8">
+      <Text className="font-display text-neutral text-xl mb-3 tracking-wide">
+        🏅 TOP JUDGES
+      </Text>
+      <View className="gap-2">
+        {(judges as Judge[]).map((j, idx) => (
+          <View
+            key={j.voter}
+            className="flex-row items-center bg-base-200 rounded-2xl px-3 py-2.5"
+          >
+            <Text className="w-7 font-display text-secondary text-base">
+              {idx + 1}
+            </Text>
+            <ProfileAvatar
+              image={j.profile?.imgUrl}
+              address={j.voter}
+              size={36}
+            />
+            <Text
+              className="flex-1 ml-3 font-bold text-neutral text-sm"
+              numberOfLines={1}
+            >
+              {j.profile?.username
+                ? j.profile.username
+                : getDisplayName(null, j.voter)}
+            </Text>
+            <View className="items-end">
+              <Text className="font-display text-neutral text-sm">
+                {j.total} votes
+              </Text>
+              <Text className="text-neutral/50 text-xs">
+                {j.accuracy.toFixed(1)}% accurate
+              </Text>
+            </View>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
 
 export default function JudgeScreen() {
   const [currentIdx, setCurrentIdx] = useState(0);
@@ -41,26 +111,24 @@ export default function JudgeScreen() {
     { enabled: !!voterAddress, staleTime: 60_000 },
   );
 
+  const allDogs = useMemo(
+    () => (query.data?.hotdogs ?? []) as ProcessedHotdog[],
+    [query.data?.hotdogs],
+  );
+
   const pending = useMemo(() => {
-    const hotdogs = (query.data?.hotdogs ?? []) as ProcessedHotdog[];
     const userAttested = query.data?.userAttested ?? [];
-    return hotdogs
+    return allDogs
       .map((h, i) => ({ h, i }))
       .filter(({ h, i }) => {
-        const inWindow =
-          h.attestationPeriod &&
-          h.attestationPeriod.status === 0 &&
-          isInAttestationWindow(
-            h.attestationPeriod.startTime,
-            h.attestationPeriod.endTime,
-          );
+        const open = isJudgeable(h.timestamp, h.attestationPeriod?.status);
         const alreadyVoted =
           voterAddress &&
           ((userAttested[i] ?? false) || userVotes?.[h.logId] !== undefined);
-        return inWindow && !alreadyVoted;
+        return open && !alreadyVoted;
       })
       .map(({ h }) => h);
-  }, [query.data?.hotdogs, query.data?.userAttested, userVotes, voterAddress]);
+  }, [allDogs, query.data?.userAttested, userVotes, voterAddress]);
 
   const validCounts = query.data?.validAttestations ?? [];
   const invalidCounts = query.data?.invalidAttestations ?? [];
@@ -69,7 +137,6 @@ export default function JudgeScreen() {
 
   const safeIdx = Math.min(currentIdx, Math.max(0, pending.length - 1));
   const dog = pending[safeIdx];
-  const allDogs = (query.data?.hotdogs ?? []) as ProcessedHotdog[];
   const globalIdx = dog ? allDogs.findIndex((h) => h.logId === dog.logId) : -1;
 
   const handleNext = useCallback(() => {
@@ -85,23 +152,12 @@ export default function JudgeScreen() {
 
   if (query.isLoading) {
     return (
-      <SafeAreaView className="flex-1 bg-base-100 items-center justify-center" edges={["bottom"]}>
+      <SafeAreaView
+        className="flex-1 bg-base-100 items-center justify-center"
+        edges={["bottom"]}
+      >
         <ActivityIndicator color={COLORS.primary} size="large" />
         <Text className="text-neutral/60 mt-3">Loading the queue…</Text>
-      </SafeAreaView>
-    );
-  }
-
-  if (pending.length === 0) {
-    return (
-      <SafeAreaView className="flex-1 bg-base-100 items-center justify-center px-8" edges={["bottom"]}>
-        <Text className="text-6xl mb-4">🎉</Text>
-        <Text className="font-display text-neutral text-2xl text-center mb-2">
-          ALL CLEAR
-        </Text>
-        <Text className="text-neutral/60 text-center text-base">
-          No dogs waiting for a verdict right now. Check back in a bit!
-        </Text>
       </SafeAreaView>
     );
   }
@@ -114,75 +170,107 @@ export default function JudgeScreen() {
 
   return (
     <SafeAreaView className="flex-1 bg-base-100" edges={["bottom"]}>
-      {/* Queue count */}
-      <View className="flex-row items-center justify-between px-4 py-2">
-        <Text className="text-neutral/60 text-sm">
-          Dog {safeIdx + 1} of {pending.length} awaiting verdict
-        </Text>
-        {pending.length > 1 && (
-          <Pressable
-            onPress={handleNext}
-            className="bg-base-200 rounded-xl px-3 py-1.5"
-          >
-            <Text className="text-neutral font-bold text-sm">Skip →</Text>
-          </Pressable>
-        )}
-      </View>
-
-      {/* Dog card */}
-      {dog && (
-        <View className="mx-4 bg-base-200 rounded-3xl overflow-hidden" style={{
-          shadowColor: COLORS.secondary,
-          shadowOffset: { width: 0, height: 8 },
-          shadowOpacity: 0.12,
-          shadowRadius: 20,
-          elevation: 4,
-        }}>
-          {/* Header */}
-          <View className="flex-row items-center p-3 gap-2">
-            <ProfileAvatar
-              image={dog.eaterProfile?.image}
-              address={dog.eater}
-              size={38}
-            />
-            <View className="flex-1">
-              <Text className="font-bold text-neutral text-sm">{eaterName}</Text>
-              <Text className="text-xs text-neutral/50">
-                {formatTimestamp(dog.timestamp)}
-              </Text>
-            </View>
+      <ScrollView contentContainerStyle={{ paddingBottom: 100 }}>
+        {pending.length === 0 ? (
+          <View className="items-center justify-center px-8 py-16">
+            <Text className="text-6xl mb-4">🎉</Text>
+            <Text className="font-display text-neutral text-2xl text-center mb-2">
+              ALL CLEAR
+            </Text>
+            <Text className="text-neutral/60 text-center text-base">
+              No dogs waiting for a verdict right now. Check back in a bit!
+            </Text>
           </View>
+        ) : (
+          <>
+            {/* Queue count */}
+            <View className="flex-row items-center justify-between px-4 py-2">
+              <Text className="text-neutral/60 text-sm">
+                Dog {safeIdx + 1} of {pending.length} awaiting verdict
+              </Text>
+              {pending.length > 1 && (
+                <Pressable
+                  onPress={handleNext}
+                  className="bg-base-200 rounded-xl px-3 py-1.5"
+                >
+                  <Text className="text-neutral font-bold text-sm">Skip →</Text>
+                </Pressable>
+              )}
+            </View>
 
-          {/* Image */}
-          <View style={{ width: width - 32, height: imageHeight }}>
-            {imageUri ? (
-              <Image
-                source={{ uri: imageUri }}
-                style={{ flex: 1 }}
-                contentFit="cover"
-                transition={300}
-              />
-            ) : (
-              <View className="flex-1 bg-base-300 items-center justify-center">
-                <Text className="text-5xl">🌭</Text>
+            {/* Dog card */}
+            {dog && (
+              <View
+                className="mx-4 bg-base-200 rounded-3xl overflow-hidden"
+                style={{
+                  shadowColor: COLORS.secondary,
+                  shadowOffset: { width: 0, height: 8 },
+                  shadowOpacity: 0.12,
+                  shadowRadius: 20,
+                  elevation: 4,
+                }}
+              >
+                {/* Header */}
+                <View className="flex-row items-center p-3 gap-2">
+                  <ProfileAvatar
+                    image={dog.eaterProfile?.image}
+                    address={dog.eater}
+                    size={38}
+                  />
+                  <View className="flex-1">
+                    <Text className="font-bold text-neutral text-sm">
+                      {eaterName}
+                    </Text>
+                    <Text className="text-xs text-neutral/50">
+                      {formatTimestamp(dog.timestamp)}
+                    </Text>
+                  </View>
+                </View>
+
+                {/* Image */}
+                <View style={{ width: width - 32, height: imageHeight }}>
+                  {imageUri ? (
+                    <Image
+                      source={{ uri: imageUri }}
+                      style={{ flex: 1 }}
+                      contentFit="cover"
+                      transition={300}
+                    />
+                  ) : (
+                    <View className="flex-1 bg-base-300 items-center justify-center">
+                      <Text className="text-5xl">🌭</Text>
+                    </View>
+                  )}
+                </View>
+
+                {/* Vote bar */}
+                {globalIdx >= 0 && (
+                  <VoteBar
+                    logId={dog.logId}
+                    validCount={validCounts[globalIdx] ?? "0"}
+                    invalidCount={invalidCounts[globalIdx] ?? "0"}
+                    userHasVoted={userAttested[globalIdx] ?? false}
+                    userVotedValid={userAttestations[globalIdx] ?? false}
+                    attestationStatus={dog.attestationPeriod?.status}
+                    onVoteSuccess={handleVoteSuccess}
+                  />
+                )}
+
+                {/* AI verdict + countdown */}
+                <View className="flex-row items-center gap-3 px-3 pb-3">
+                  <AiJudgement logId={dog.logId} timestamp={dog.timestamp} />
+                  <VotingCountdown timestamp={dog.timestamp} />
+                </View>
               </View>
             )}
-          </View>
+          </>
+        )}
 
-          {/* Vote bar */}
-          {globalIdx >= 0 && (
-            <VoteBar
-              logId={dog.logId}
-              validCount={validCounts[globalIdx] ?? "0"}
-              invalidCount={invalidCounts[globalIdx] ?? "0"}
-              userHasVoted={userAttested[globalIdx] ?? false}
-              userVotedValid={userAttestations[globalIdx] ?? false}
-              attestationStatus={dog.attestationPeriod?.status}
-              onVoteSuccess={handleVoteSuccess}
-            />
-          )}
+        {/* Top judges ranking */}
+        <View className="mt-6">
+          <TopJudges />
         </View>
-      )}
+      </ScrollView>
     </SafeAreaView>
   );
 }

--- a/mobile/app/(tabs)/judge.tsx
+++ b/mobile/app/(tabs)/judge.tsx
@@ -9,6 +9,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Image } from "expo-image";
+import { useRouter } from "expo-router";
 import { trpc } from "~/utils/trpc";
 import { CHAIN_ID, ZERO_ADDRESS } from "~/constants";
 import { useAuth } from "~/providers/AuthProvider";

--- a/mobile/app/(tabs)/judge.tsx
+++ b/mobile/app/(tabs)/judge.tsx
@@ -33,6 +33,7 @@ interface Judge {
 }
 
 function TopJudges() {
+  const router = useRouter();
   const { data: judges = [], isLoading } = trpc.hotdog.getJudges.useQuery(
     undefined,
     { refetchOnWindowFocus: false, retry: 1 },
@@ -54,8 +55,9 @@ function TopJudges() {
       </Text>
       <View className="gap-2">
         {(judges as Judge[]).map((j, idx) => (
-          <View
+          <Pressable
             key={j.voter}
+            onPress={() => router.push(`/profile/address/${j.voter}` as never)}
             className="flex-row items-center bg-base-200 rounded-2xl px-3 py-2.5"
           >
             <Text className="w-7 font-display text-secondary text-base">
@@ -82,7 +84,7 @@ function TopJudges() {
                 {j.accuracy.toFixed(1)}% accurate
               </Text>
             </View>
-          </View>
+          </Pressable>
         ))}
       </View>
     </View>

--- a/mobile/app/(tabs)/profile.tsx
+++ b/mobile/app/(tabs)/profile.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "expo-router";
 import { useAuth } from "~/providers/AuthProvider";
 import { ProfileAvatar } from "~/components/ProfileAvatar";
 import { HotdogFeed } from "~/components/HotdogFeed";
+import { NotificationsSettings } from "~/components/NotificationsSettings";
 import { formatAddress } from "~/utils/format";
 
 export default function ProfileScreen() {
@@ -88,6 +89,16 @@ export default function ProfileScreen() {
             <Text className="text-neutral font-bold text-sm">💰 Earn & Stake $HOTDOG</Text>
             <Text className="text-neutral/40">→</Text>
           </Pressable>
+
+          <Pressable
+            onPress={() => router.push("/faq")}
+            className="mt-3 bg-base-200 rounded-xl px-3 py-2 flex-row items-center justify-between"
+          >
+            <Text className="text-neutral font-bold text-sm">📖 How it works · FAQ</Text>
+            <Text className="text-neutral/40">→</Text>
+          </Pressable>
+
+          <NotificationsSettings address={session.address} fid={session.fid} />
         </View>
 
         {/* User's dog feed */}

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -78,6 +78,18 @@ export default function RootLayout() {
                 },
               }}
             />
+            <Stack.Screen
+              name="profile/address/[address]"
+              options={{
+                headerTitle: "Profile",
+                headerStyle: { backgroundColor: "#FFF8EC" },
+                headerTintColor: "#1E1A17",
+                headerTitleStyle: {
+                  fontFamily: "Anton_400Regular",
+                  letterSpacing: 1,
+                },
+              }}
+            />
           </Stack>
         </TRPCProvider>
       </AuthProvider>

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -37,7 +37,6 @@ export default function RootLayout() {
                 headerTintColor: "#1E1A17",
                 headerTitleStyle: {
                   fontFamily: "Anton_400Regular",
-                  letterSpacing: 1,
                 },
               }}
             />
@@ -49,7 +48,6 @@ export default function RootLayout() {
                 headerTintColor: "#1E1A17",
                 headerTitleStyle: {
                   fontFamily: "Anton_400Regular",
-                  letterSpacing: 1,
                 },
                 presentation: "modal",
               }}
@@ -62,7 +60,6 @@ export default function RootLayout() {
                 headerTintColor: "#1E1A17",
                 headerTitleStyle: {
                   fontFamily: "Anton_400Regular",
-                  letterSpacing: 1,
                 },
               }}
             />
@@ -74,7 +71,6 @@ export default function RootLayout() {
                 headerTintColor: "#1E1A17",
                 headerTitleStyle: {
                   fontFamily: "Anton_400Regular",
-                  letterSpacing: 1,
                 },
               }}
             />
@@ -86,7 +82,6 @@ export default function RootLayout() {
                 headerTintColor: "#1E1A17",
                 headerTitleStyle: {
                   fontFamily: "Anton_400Regular",
-                  letterSpacing: 1,
                 },
               }}
             />
@@ -98,7 +93,6 @@ export default function RootLayout() {
                 headerTintColor: "#1E1A17",
                 headerTitleStyle: {
                   fontFamily: "Anton_400Regular",
-                  letterSpacing: 1,
                 },
               }}
             />

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -90,6 +90,18 @@ export default function RootLayout() {
                 },
               }}
             />
+            <Stack.Screen
+              name="poidh"
+              options={{
+                headerTitle: "POIDH Campaign",
+                headerStyle: { backgroundColor: "#FFF8EC" },
+                headerTintColor: "#1E1A17",
+                headerTitleStyle: {
+                  fontFamily: "Anton_400Regular",
+                  letterSpacing: 1,
+                },
+              }}
+            />
           </Stack>
         </TRPCProvider>
       </AuthProvider>

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -66,6 +66,18 @@ export default function RootLayout() {
                 },
               }}
             />
+            <Stack.Screen
+              name="faq"
+              options={{
+                headerTitle: "FAQ & Rules",
+                headerStyle: { backgroundColor: "#FFF8EC" },
+                headerTintColor: "#1E1A17",
+                headerTitleStyle: {
+                  fontFamily: "Anton_400Regular",
+                  letterSpacing: 1,
+                },
+              }}
+            />
           </Stack>
         </TRPCProvider>
       </AuthProvider>

--- a/mobile/app/dog/[logId].tsx
+++ b/mobile/app/dog/[logId].tsx
@@ -11,8 +11,6 @@ import {
 import { Image } from "expo-image";
 import { useLocalSearchParams } from "expo-router";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { trpc } from "~/utils/trpc";
-import { CHAIN_ID, ZERO_ADDRESS } from "~/constants";
 import { ProfileAvatar } from "~/components/ProfileAvatar";
 import { ProfileBadge } from "~/components/ProfileBadge";
 import { VerdictStamp } from "~/components/VerdictStamp";
@@ -28,24 +26,26 @@ import {
   getDisplayName,
 } from "~/utils/format";
 import { useAuth } from "~/providers/AuthProvider";
+import { useHotdog } from "~/hooks/useHotdogs";
 
 export default function DogDetailScreen() {
   const { logId } = useLocalSearchParams<{ logId: string }>();
   const { session } = useAuth();
   const { width } = useWindowDimensions();
 
-  const query = trpc.hotdog.getById.useQuery(
-    {
-      chainId: CHAIN_ID,
-      user: session?.address ?? ZERO_ADDRESS,
-      logId: logId ?? "",
-    },
-    { enabled: !!logId },
-  );
+  const {
+    hotdog,
+    validAttestations,
+    invalidAttestations,
+    userAttested,
+    userAttestation,
+    isLoading,
+    refetch,
+  } = useHotdog(logId ?? "", session?.address);
 
   const imageHeight = Math.round(width * (5 / 4));
 
-  if (query.isLoading) {
+  if (isLoading) {
     return (
       <SafeAreaView
         className="flex-1 bg-base-100 items-center justify-center"
@@ -56,7 +56,7 @@ export default function DogDetailScreen() {
     );
   }
 
-  if (!query.data?.hotdog) {
+  if (!hotdog) {
     return (
       <SafeAreaView
         className="flex-1 bg-base-100 items-center justify-center px-8"
@@ -67,7 +67,7 @@ export default function DogDetailScreen() {
           Dog not found or still indexing. Pull to refresh.
         </Text>
         <Pressable
-          onPress={() => query.refetch()}
+          onPress={refetch}
           className="mt-4 bg-primary rounded-xl px-6 py-3"
         >
           <Text className="font-bold text-neutral">Retry</Text>
@@ -75,9 +75,6 @@ export default function DogDetailScreen() {
       </SafeAreaView>
     );
   }
-
-  const { hotdog, validAttestations, invalidAttestations, userAttested, userAttestation } =
-    query.data;
 
   const imageUri = convertIpfsToHttps(
     hotdog.zoraCoin?.mediaContent?.previewImage?.medium ?? hotdog.imageUri,
@@ -142,7 +139,7 @@ export default function DogDetailScreen() {
           userHasVoted={userAttested ?? false}
           userVotedValid={userAttestation ?? false}
           attestationStatus={hotdog.attestationPeriod?.status}
-          onVoteSuccess={() => query.refetch()}
+          onVoteSuccess={refetch}
         />
 
         {/* AI verdict + live voting countdown */}

--- a/mobile/app/dog/[logId].tsx
+++ b/mobile/app/dog/[logId].tsx
@@ -17,7 +17,11 @@ import { ProfileAvatar } from "~/components/ProfileAvatar";
 import { ProfileBadge } from "~/components/ProfileBadge";
 import { VerdictStamp } from "~/components/VerdictStamp";
 import { VoteBar } from "~/components/VoteBar";
+import { AiJudgement } from "~/components/AiJudgement";
+import { VotingCountdown } from "~/components/VotingCountdown";
+import { Comments } from "~/components/Comments";
 import { COLORS } from "~/constants/colors";
+import { formatAbbreviatedFiat } from "@shared/format";
 import {
   convertIpfsToHttps,
   formatTimestamp,
@@ -141,6 +145,14 @@ export default function DogDetailScreen() {
           onVoteSuccess={() => query.refetch()}
         />
 
+        {/* AI verdict + live voting countdown */}
+        <View className="flex-row items-center gap-3 px-4 pb-1">
+          <AiJudgement logId={hotdog.logId} timestamp={hotdog.timestamp} />
+          {hotdog.attestationPeriod && !isResolved && (
+            <VotingCountdown timestamp={hotdog.timestamp} />
+          )}
+        </View>
+
         {/* Metadata */}
         <View className="px-4 pb-8 gap-4">
           {/* Log ID */}
@@ -174,25 +186,68 @@ export default function DogDetailScreen() {
             </View>
           )}
 
-          {/* Zora coin */}
-          {hotdog.zoraCoin?.link && (
-            <Pressable
-              onPress={() => Linking.openURL(hotdog.zoraCoin!.link!)}
-              className="bg-base-200 rounded-xl px-4 py-3 flex-row items-center justify-between"
-            >
-              <View>
-                <Text className="text-neutral/50 text-xs mb-0.5">Zora Coin</Text>
-                <Text className="text-neutral font-bold text-sm">
-                  {hotdog.zoraCoin.symbol ?? "COIN"}
-                </Text>
-                {hotdog.zoraCoin.marketCap && (
-                  <Text className="text-info text-xs">
-                    Ξ {parseFloat(hotdog.zoraCoin.marketCap).toFixed(6)} mcap
+          {/* Zora coin — market stats + trade */}
+          {hotdog.zoraCoin && (
+            <View className="bg-base-200 rounded-xl px-4 py-3 gap-3">
+              <View className="flex-row items-center justify-between">
+                <View>
+                  <Text className="text-neutral/50 text-xs mb-0.5">Zora Coin</Text>
+                  <Text className="text-neutral font-bold text-sm">
+                    {hotdog.zoraCoin.symbol ?? "COIN"}
                   </Text>
+                </View>
+                {typeof hotdog.zoraCoin.uniqueHolders === "number" && (
+                  <View className="items-end">
+                    <Text className="text-neutral/50 text-xs">Holders</Text>
+                    <Text className="text-neutral font-bold text-sm">
+                      {hotdog.zoraCoin.uniqueHolders}
+                    </Text>
+                  </View>
                 )}
               </View>
-              <Text className="text-neutral/40 text-xl">→</Text>
-            </Pressable>
+
+              <View className="flex-row justify-between">
+                {hotdog.zoraCoin.marketCap && (
+                  <View>
+                    <Text className="text-neutral/50 text-xs">Market cap</Text>
+                    <Text className="text-info font-bold text-sm">
+                      ${formatAbbreviatedFiat(Number(hotdog.zoraCoin.marketCap))}
+                    </Text>
+                  </View>
+                )}
+                {hotdog.zoraCoin.volume24h && (
+                  <View className="items-end">
+                    <Text className="text-neutral/50 text-xs">24h volume</Text>
+                    <Text className="text-neutral font-bold text-sm">
+                      ${formatAbbreviatedFiat(Number(hotdog.zoraCoin.volume24h))}
+                    </Text>
+                  </View>
+                )}
+              </View>
+
+              <View className="flex-row gap-2">
+                <Pressable
+                  onPress={() =>
+                    Linking.openURL(
+                      `https://zora.co/coin/base:${hotdog.zoraCoin!.address}`,
+                    )
+                  }
+                  className="flex-1 bg-primary rounded-xl py-2.5 items-center"
+                >
+                  <Text className="font-bold text-neutral text-sm">
+                    ⇄ Trade on Zora
+                  </Text>
+                </Pressable>
+                {hotdog.zoraCoin.link && (
+                  <Pressable
+                    onPress={() => Linking.openURL(hotdog.zoraCoin!.link!)}
+                    className="bg-base-300 rounded-xl py-2.5 px-4 items-center justify-center"
+                  >
+                    <Text className="text-neutral/70 text-sm font-bold">View</Text>
+                  </Pressable>
+                )}
+              </View>
+            </View>
           )}
 
           {/* Duplicate warning */}
@@ -204,6 +259,9 @@ export default function DogDetailScreen() {
             </View>
           )}
         </View>
+
+        {/* Comments */}
+        <Comments logId={hotdog.logId} />
       </ScrollView>
     </SafeAreaView>
   );

--- a/mobile/app/faq.tsx
+++ b/mobile/app/faq.tsx
@@ -1,0 +1,124 @@
+import React, { useState } from "react";
+import { Linking, Pressable, ScrollView, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+interface SectionProps {
+  title: string;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+}
+
+function Collapsible({ title, children, defaultOpen = false }: SectionProps) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <View className="bg-base-200 rounded-2xl mb-3 overflow-hidden">
+      <Pressable
+        onPress={() => setOpen((o) => !o)}
+        className="flex-row items-center justify-between px-4 py-3.5"
+      >
+        <Text className="font-bold text-neutral text-base flex-1 pr-2">
+          {title}
+        </Text>
+        <Text className="text-neutral/50 text-lg">{open ? "▲" : "▼"}</Text>
+      </Pressable>
+      {open && <View className="px-4 pb-4 gap-2">{children}</View>}
+    </View>
+  );
+}
+
+function Bullet({ children }: { children: React.ReactNode }) {
+  return (
+    <View className="flex-row gap-2">
+      <Text className="text-neutral/60">•</Text>
+      <Text className="text-neutral/70 text-sm leading-relaxed flex-1">
+        {children}
+      </Text>
+    </View>
+  );
+}
+
+function Heading({ children }: { children: React.ReactNode }) {
+  return (
+    <Text className="font-bold text-neutral text-sm mt-2 mb-0.5">{children}</Text>
+  );
+}
+
+export default function FaqScreen() {
+  return (
+    <SafeAreaView className="flex-1 bg-base-100" edges={["bottom"]}>
+      <ScrollView contentContainerStyle={{ padding: 16, paddingBottom: 80 }}>
+        <Text className="font-display text-neutral text-3xl mb-1 tracking-wide">
+          🌭 FAQ & RULES
+        </Text>
+        <Text className="text-neutral/60 text-sm mb-5">
+          Welcome to the global hotdog eating competition!
+        </Text>
+
+        <Collapsible title="What is Log a Dog?" defaultOpen>
+          <Heading>A global competition with a simple, challenging goal:</Heading>
+          <Bullet>Eat as many hotdogs as you can during Summer 2026 (Jul 4 – Sep 7).</Bullet>
+          <Bullet>Record each hotdog by uploading a pic of you eating it.</Bullet>
+          <Bullet>Compete against participants from all around the world.</Bullet>
+          <Bullet>Rate the truthfulness of other submissions.</Bullet>
+          <Bullet>Creative and dedicated loggers get rewarded along the way.</Bullet>
+          <Heading>Powered by A.I. and blockchain</Heading>
+          <Bullet>Logging a dog records a transaction on the blockchain.</Bullet>
+          <Bullet>Users make onchain attestations about your logs to prove truthfulness.</Bullet>
+          <Bullet>An AI bot attests automatically based on what it sees in the image.</Bullet>
+        </Collapsible>
+
+        <Collapsible title="What constitutes a hotdog?">
+          <Heading>A valid hotdog:</Heading>
+          <Bullet>Is at least 4.8 inches long.</Bullet>
+          <Bullet>Is in a bun (gluten-free only if necessary).</Bullet>
+          <Heading>Sausages, bratwursts, or other sausage-like foods?</Heading>
+          <Bullet>Doesn&apos;t count.</Bullet>
+          <Heading>Two dogs on one bun?</Heading>
+          <Bullet>That is one dog.</Bullet>
+          <Heading>A very long hotdog?</Heading>
+          <Bullet>That is one dog.</Bullet>
+          <Heading>Pigs-in-a-blanket equal to one hotdog?</Heading>
+          <Bullet>No.</Bullet>
+          <Heading>Do vegetarian or vegan hotdogs count?</Heading>
+          <Bullet>Yes, but we&apos;re not happy about it.</Bullet>
+          <Heading>Condiments or toppings?</Heading>
+          <Bullet>No effect. Eat it plain or add as many toppings as you like.</Bullet>
+        </Collapsible>
+
+        <Collapsible title="How do I earn from eating hotdogs?">
+          <Heading>Eat to Earn</Heading>
+          <Bullet>Upload a pic of you eating a hotdog (one pic per dog).</Bullet>
+          <Bullet>Your pic becomes a tradeable onchain token where you earn trading fees.</Bullet>
+          <Bullet>Rewards throughout the summer for creative and standout dogs.</Bullet>
+          <Heading>Moderate to Earn</Heading>
+          <Bullet>Stake $HOTDOG to become a judge.</Bullet>
+          <Bullet>Upvote pics of people eating hotdogs — you need to see the person eating it!</Bullet>
+          <Bullet>Downvote spam, duplicates, and off-topic content.</Bullet>
+          <Bullet>Incorrect votes are slashed and distributed to the correct voters.</Bullet>
+        </Collapsible>
+
+        <Collapsible title="How it works — step by step">
+          <Heading>1. Log a dog</Heading>
+          <Bullet>Upload a picture of you eating a hotdog. One pic per dog.</Bullet>
+          <Heading>2. Climb the leaderboard</Heading>
+          <Bullet>Keep logging — creative dogs get rewarded throughout the summer.</Bullet>
+          <Heading>3. Judge others</Heading>
+          <Bullet>Stake $HOTDOG and vote on submissions to earn rewards for accurate verdicts.</Bullet>
+        </Collapsible>
+
+        <Collapsible title="Why does this exist?">
+          <Text className="text-neutral/70 text-sm leading-relaxed">
+            The world needs this.
+          </Text>
+        </Collapsible>
+
+        <Pressable
+          onPress={() => Linking.openURL("https://www.logadog.xyz/faq")}
+          className="mt-2 bg-primary rounded-2xl py-3 items-center"
+        >
+          <Text className="font-bold text-neutral">Read the full FAQ on the web</Text>
+        </Pressable>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/mobile/app/poidh.tsx
+++ b/mobile/app/poidh.tsx
@@ -1,0 +1,147 @@
+import React from "react";
+import { Linking, Pressable, ScrollView, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useRouter } from "expo-router";
+
+const POIDH_BOUNTY_URL = "https://poidh.xyz/base/bounty/1265";
+
+const STEPS = [
+  { emoji: "🌭", title: "Eat a hotdog", body: "It must be a real dog — 4.8+ inches, in a bun." },
+  { emoji: "📷", title: "Snap the proof", body: "Photograph yourself actively mid-bite. The camera needs to catch you in the act." },
+  { emoji: "⬆️", title: "Log it onchain", body: "Upload your photo on Log a Dog. Your submission gets recorded on Base." },
+  { emoji: "📢", title: "Share on Farcaster or X", body: "Post your logged submission publicly. Copy the link — you'll need it next." },
+  { emoji: "🕹️", title: "Submit your claim on POIDH", body: "Paste your social post link as a bounty claim at poidh.xyz. That's your entry." },
+];
+
+const WINNING_CRITERIA = [
+  { label: "Creative presentation", emoji: "🎨" },
+  { label: "Humor", emoji: "😂" },
+  { label: "Photographic quality", emoji: "📸" },
+  { label: "Originality", emoji: "✨" },
+];
+
+const REQUIREMENTS = [
+  "Hotdog is 4.8+ inches long, served in a bun",
+  "You are visibly mid-bite in the photo",
+  "Submission is logged on logadog.xyz (onchain via Base)",
+  "Logged submission is shared on Farcaster or X",
+  "Social post link is submitted as a claim on poidh.xyz",
+];
+
+export default function PoidhScreen() {
+  const router = useRouter();
+  const openPoidh = () => Linking.openURL(POIDH_BOUNTY_URL);
+
+  return (
+    <SafeAreaView className="flex-1 bg-base-100" edges={["bottom"]}>
+      <ScrollView contentContainerStyle={{ padding: 16, paddingBottom: 60 }} className="gap-4">
+        {/* Hero */}
+        <View className="items-center mb-4">
+          <Text className="font-display text-4xl mb-1">🌭 × 🕹️</Text>
+          <Text className="font-display text-neutral text-3xl tracking-wide">
+            POIDH CAMPAIGN
+          </Text>
+          <Text className="text-neutral/60 text-sm mt-1 text-center">
+            Log a Dog meets &quot;Pics or it didn&apos;t happen&quot;
+          </Text>
+        </View>
+
+        {/* Prize banner */}
+        <View className="bg-secondary rounded-3xl p-5 mb-4 flex-row items-center justify-between">
+          <View className="flex-1 pr-3">
+            <Text className="font-display text-white/80 text-xs tracking-widest">
+              JULY 4 – 6, 2026
+            </Text>
+            <Text className="font-display text-white text-xl">
+              THREE DAYS. THREE WINNERS.
+            </Text>
+            <Text className="text-white/80 text-sm mt-1">
+              One winner picked per day by the organizers.
+            </Text>
+          </View>
+          <View className="items-center">
+            <Text className="font-display text-white text-3xl">$50</Text>
+            <Text className="font-display text-white/80 text-xs tracking-widest">
+              ETH / DAY
+            </Text>
+          </View>
+        </View>
+
+        {/* How to participate */}
+        <Text className="font-display text-neutral text-xl mb-3 tracking-wide">
+          🎯 HOW TO PARTICIPATE
+        </Text>
+        <View className="gap-3 mb-4">
+          {STEPS.map((step, idx) => (
+            <View key={idx} className="flex-row items-start gap-3">
+              <View className="bg-primary rounded-full w-7 h-7 items-center justify-center">
+                <Text className="font-bold text-neutral text-sm">{idx + 1}</Text>
+              </View>
+              <View className="flex-1">
+                <Text className="font-bold text-neutral text-sm">
+                  {step.emoji} {step.title}
+                </Text>
+                <Text className="text-neutral/60 text-sm">{step.body}</Text>
+              </View>
+            </View>
+          ))}
+        </View>
+
+        {/* Winning criteria */}
+        <Text className="font-display text-neutral text-xl mb-3 tracking-wide">
+          🏆 WINNING CRITERIA
+        </Text>
+        <View className="flex-row flex-wrap gap-3 mb-4">
+          {WINNING_CRITERIA.map((c) => (
+            <View
+              key={c.label}
+              className="bg-base-200 rounded-2xl px-3 py-2.5 flex-row items-center gap-2"
+              style={{ width: "47%" }}
+            >
+              <Text className="text-xl">{c.emoji}</Text>
+              <Text className="text-neutral text-sm font-bold flex-1">
+                {c.label}
+              </Text>
+            </View>
+          ))}
+        </View>
+
+        {/* Requirements */}
+        <Text className="font-display text-neutral text-xl mb-3 tracking-wide">
+          ✅ ENTRY REQUIREMENTS
+        </Text>
+        <View className="gap-2 mb-6">
+          {REQUIREMENTS.map((req) => (
+            <View key={req} className="flex-row items-start gap-2">
+              <Text className="text-accent">✓</Text>
+              <Text className="text-neutral/70 text-sm flex-1">{req}</Text>
+            </View>
+          ))}
+        </View>
+
+        {/* CTAs */}
+        <Pressable
+          onPress={() => router.push("/" as never)}
+          className="bg-primary rounded-2xl py-4 items-center mb-3"
+        >
+          <Text className="font-display text-neutral text-lg tracking-wide">
+            📷 LOG YOUR DOG 🌭
+          </Text>
+        </Pressable>
+        <Pressable
+          onPress={openPoidh}
+          className="border-2 border-base-300 rounded-2xl py-4 items-center"
+        >
+          <Text className="font-display text-neutral tracking-wide">
+            💰 SUBMIT CLAIM ON POIDH 🕹️
+          </Text>
+        </Pressable>
+
+        <Text className="text-neutral/40 text-xs text-center mt-4">
+          Campaign runs July 4–6, 2026. One $50 ETH prize awarded per day.
+          Winners selected by organizers based on quality and creativity.
+        </Text>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/mobile/app/profile/address/[address].tsx
+++ b/mobile/app/profile/address/[address].tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { Linking, Pressable, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useLocalSearchParams } from "expo-router";
+import { trpc } from "~/utils/trpc";
+import { CHAIN_ID } from "~/constants";
+import { HotdogFeed } from "~/components/HotdogFeed";
+import { ProfileAvatar } from "~/components/ProfileAvatar";
+import { formatAddress } from "~/utils/format";
+
+interface UserProfile {
+  username?: string;
+  imgUrl?: string;
+  address?: string;
+}
+
+export default function PublicProfileScreen() {
+  const { address } = useLocalSearchParams<{ address: string }>();
+  const addr = address ?? "";
+
+  const { data: profile } = trpc.profile.getByAddress.useQuery(
+    { chainId: CHAIN_ID, address: addr },
+    { enabled: !!addr, refetchOnWindowFocus: false },
+  );
+
+  const p = profile as UserProfile | undefined;
+  const name = p?.username ? p.username : formatAddress(addr);
+
+  const header = (
+    <View className="px-4 pt-4 pb-2">
+      <View className="flex-row items-center gap-3">
+        <ProfileAvatar image={p?.imgUrl} address={addr} size={64} />
+        <View className="flex-1">
+          <Text className="font-bold text-neutral text-lg" numberOfLines={1}>
+            {name}
+          </Text>
+          <Text className="text-neutral/40 text-xs font-mono">
+            {formatAddress(addr)}
+          </Text>
+        </View>
+        <Pressable
+          onPress={() =>
+            Linking.openURL(`https://www.logadog.xyz/profile/address/${addr}`)
+          }
+          className="bg-base-200 rounded-xl px-3 py-2"
+        >
+          <Text className="text-neutral/60 text-xs font-bold">Web ↗</Text>
+        </Pressable>
+      </View>
+      <Text className="text-neutral/50 text-sm mt-4 mb-1 font-bold uppercase tracking-wider">
+        Their dogs
+      </Text>
+    </View>
+  );
+
+  return (
+    <SafeAreaView className="flex-1 bg-base-100" edges={["bottom"]}>
+      <HotdogFeed userAddress={addr} header={header} />
+    </SafeAreaView>
+  );
+}

--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -4,6 +4,12 @@ const path = require("path");
 
 const config = getDefaultConfig(__dirname);
 
+// Shared data layer lives at repo root in ../shared and is consumed via the
+// "@shared" alias. Metro must watch it (it's outside the project root) and be
+// told how to resolve the alias.
+const sharedRoot = path.resolve(__dirname, "../shared");
+config.watchFolders = [...(config.watchFolders ?? []), sharedRoot];
+
 // Required for Thirdweb React Native v5 package exports
 config.resolver.unstable_enablePackageExports = true;
 config.resolver.unstable_conditionNames = [
@@ -25,4 +31,28 @@ config.resolver.extraNodeModules = {
   ),
 };
 
-module.exports = withNativeWind(config, { input: "./global.css" });
+const nativeWindConfig = withNativeWind(config, { input: "./global.css" });
+
+// Resolve the "@shared" alias to the repo-root shared/ data layer. A custom
+// resolveRequest is used (instead of extraNodeModules) because "@shared/..."
+// looks like a scoped package to Metro's default resolver, which wouldn't map
+// the subpath. Applied after withNativeWind so it isn't overwritten.
+const baseResolveRequest = nativeWindConfig.resolver.resolveRequest;
+nativeWindConfig.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (moduleName === "@shared" || moduleName.startsWith("@shared/")) {
+    const sub =
+      moduleName === "@shared" ? "index" : moduleName.slice("@shared/".length);
+    return context.resolveRequest(
+      context,
+      path.resolve(sharedRoot, sub),
+      platform
+    );
+  }
+  return (baseResolveRequest ?? context.resolveRequest)(
+    context,
+    moduleName,
+    platform
+  );
+};
+
+module.exports = nativeWindConfig;

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -7,7 +7,8 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@coinbase/wallet-mobile-sdk": "^1.0.7",

--- a/mobile/src/components/AiJudgement.tsx
+++ b/mobile/src/components/AiJudgement.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from "react";
+import { Modal, Pressable, Text, View } from "react-native";
+import { trpc } from "~/utils/trpc";
+import { CHAIN_ID } from "~/constants";
+
+interface Props {
+  logId: string;
+  timestamp: string;
+}
+
+/**
+ * Shows the AI moderator's verdict for a log (the mobile counterpart to the web
+ * AiJudgement). The AI bot auto-attests based on what it sees in the image; this
+ * surfaces that as a small badge with an explanatory sheet.
+ */
+export function AiJudgement({ logId, timestamp }: Props) {
+  const [open, setOpen] = useState(false);
+  const { data } = trpc.hotdog.getAiVerificationStatus.useQuery(
+    { chainId: CHAIN_ID, logId, timestamp },
+    { refetchOnMount: false, refetchOnWindowFocus: false, retry: 1 },
+  );
+
+  if (data !== "VERIFIED" && data !== "REJECTED") return null;
+  const verified = data === "VERIFIED";
+
+  return (
+    <>
+      <Pressable
+        onPress={() => setOpen(true)}
+        className={[
+          "flex-row items-center gap-1 rounded-full px-2 py-1",
+          verified ? "bg-accent/10" : "bg-secondary/10",
+        ].join(" ")}
+      >
+        <Text className="text-xs">{verified ? "🛡️" : "⚠️"}</Text>
+        <Text
+          className={[
+            "text-xs font-bold",
+            verified ? "text-accent" : "text-secondary",
+          ].join(" ")}
+        >
+          {verified ? "AI Verified" : "AI Refuted"}
+        </Text>
+      </Pressable>
+
+      <Modal
+        visible={open}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setOpen(false)}
+      >
+        <Pressable
+          className="flex-1 bg-black/50 items-center justify-center px-6"
+          onPress={() => setOpen(false)}
+        >
+          <View className="bg-base-100 rounded-3xl p-6 w-full max-w-md">
+            <Text className="font-display text-neutral text-2xl mb-3 tracking-wide">
+              {verified ? "🛡️ AI Verified" : "⚠️ AI Refuted"}
+            </Text>
+            <Text className="text-neutral/70 text-sm leading-relaxed mb-3">
+              {verified
+                ? "Our AI bot found someone eating a hotdog in this photo and gave the submission one upvote."
+                : "Our AI bot did not find anyone eating a hotdog in this photo and gave the submission one downvote."}
+            </Text>
+            <Text className="text-neutral/60 text-sm leading-relaxed mb-5">
+              AI bots can be wrong — use your own judgement when upvoting or
+              downvoting.
+            </Text>
+            <Pressable
+              onPress={() => setOpen(false)}
+              className="bg-primary rounded-2xl py-3 items-center"
+            >
+              <Text className="font-bold text-neutral">Got it</Text>
+            </Pressable>
+          </View>
+        </Pressable>
+      </Modal>
+    </>
+  );
+}

--- a/mobile/src/components/Comments.tsx
+++ b/mobile/src/components/Comments.tsx
@@ -1,0 +1,117 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { ActivityIndicator, Pressable, Text, View } from "react-native";
+import * as WebBrowser from "expo-web-browser";
+import { ProfileAvatar } from "~/components/ProfileAvatar";
+import { API_URL } from "~/constants";
+import { COLORS } from "~/constants/colors";
+import { formatAddress, formatTimestamp } from "@shared/format";
+
+interface CommentAuthor {
+  address: string;
+  ens?: { name?: string; avatarUrl?: string };
+  farcaster?: { pfpUrl?: string };
+}
+
+interface CommentItem {
+  id: string;
+  content: string;
+  author: CommentAuthor;
+  createdAt: string;
+}
+
+interface Props {
+  logId: string;
+}
+
+// Comments are posted on-chain from a user wallet (ECP.eth), which the mobile
+// app doesn't hold — writes go through the server wallet. So mobile shows the
+// conversation read-only and hands posting off to the web app.
+export function Comments({ logId }: Props) {
+  const targetUri = `https://logadog.xyz/dog/${logId}`;
+  const [comments, setComments] = useState<CommentItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ targetUri, limit: "50" });
+      const res = await fetch(`${API_URL}/api/comments?${params.toString()}`);
+      if (res.ok) {
+        const json = (await res.json()) as { results?: CommentItem[] };
+        setComments(json.results ?? []);
+      }
+    } catch {
+      // network error — leave list empty
+    } finally {
+      setLoading(false);
+    }
+  }, [targetUri]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const openWebToComment = () => {
+    void WebBrowser.openBrowserAsync(`${API_URL}/dog/${logId}`);
+  };
+
+  const toUnixSeconds = (iso: string) =>
+    String(Math.floor(new Date(iso).getTime() / 1000));
+
+  return (
+    <View className="px-4 pt-2 pb-8">
+      <View className="flex-row items-center justify-between mb-3">
+        <Text className="font-display text-neutral text-lg tracking-wide">
+          💬 Comments
+        </Text>
+        <Pressable onPress={openWebToComment} className="bg-base-200 rounded-full px-3 py-1.5">
+          <Text className="text-neutral/70 text-xs font-bold">Add a comment</Text>
+        </Pressable>
+      </View>
+
+      {loading ? (
+        <View className="py-8 items-center">
+          <ActivityIndicator color={COLORS.primary} />
+        </View>
+      ) : comments.length === 0 ? (
+        <View className="py-8 items-center">
+          <Text className="text-3xl mb-2">💬</Text>
+          <Text className="text-neutral/50 text-sm text-center">
+            No comments yet. Be the first to share your thoughts!
+          </Text>
+        </View>
+      ) : (
+        <View className="gap-4">
+          {comments.map((c) => {
+            const name =
+              c.author?.ens?.name ?? formatAddress(c.author?.address);
+            const avatar =
+              c.author?.ens?.avatarUrl ?? c.author?.farcaster?.pfpUrl ?? null;
+            return (
+              <View key={c.id} className="flex-row gap-3">
+                <ProfileAvatar
+                  image={avatar}
+                  address={c.author?.address}
+                  size={36}
+                />
+                <View className="flex-1">
+                  <View className="flex-row items-center gap-2">
+                    <Text className="font-bold text-neutral text-sm" numberOfLines={1}>
+                      {name}
+                    </Text>
+                    <Text className="text-neutral/40 text-xs">
+                      {formatTimestamp(toUnixSeconds(c.createdAt))}
+                    </Text>
+                  </View>
+                  <Text className="text-neutral/80 text-sm mt-0.5">
+                    {c.content}
+                  </Text>
+                </View>
+              </View>
+            );
+          })}
+        </View>
+      )}
+    </View>
+  );
+}

--- a/mobile/src/components/HotdogCard.tsx
+++ b/mobile/src/components/HotdogCard.tsx
@@ -23,6 +23,8 @@ interface Props {
   userVotedValid: boolean;
   onVoteSuccess?: () => void;
   showAiJudgement?: boolean;
+  /** Optimistic card for a log still confirming on-chain. */
+  pending?: boolean;
 }
 
 export function HotdogCard({
@@ -33,6 +35,7 @@ export function HotdogCard({
   userVotedValid,
   onVoteSuccess,
   showAiJudgement = false,
+  pending = false,
 }: Props) {
   const router = useRouter();
   const { width } = useWindowDimensions();
@@ -71,13 +74,18 @@ export function HotdogCard({
         shadowOpacity: 0.12,
         shadowRadius: 20,
         elevation: 4,
+        opacity: pending ? 0.7 : 1,
       }}
     >
       {/* Header + Image — tapping navigates to dog detail page */}
-      <Pressable onPress={() => router.push(`/dog/${hotdog.logId}` as never)}>
+      <Pressable
+        disabled={pending}
+        onPress={() => router.push(`/dog/${hotdog.logId}` as never)}
+      >
         {/* Header — tapping the eater navigates to their profile */}
         <View className="flex-row items-center p-3 gap-2">
           <Pressable
+            disabled={pending}
             className="flex-row items-center gap-2 flex-1"
             onPress={() =>
               router.push(`/profile/address/${hotdog.eater}` as never)
@@ -131,47 +139,59 @@ export function HotdogCard({
         </View>
       </Pressable>
 
-      {/* Vote bar — outside navigation pressable so taps register correctly */}
-      <VoteBar
-        logId={hotdog.logId}
-        validCount={validCount}
-        invalidCount={invalidCount}
-        userHasVoted={userHasVoted}
-        userVotedValid={userVotedValid}
-        attestationStatus={hotdog.attestationPeriod?.status}
-        onVoteSuccess={onVoteSuccess}
-      />
-
-      {/* Meta row — AI verdict + live voting countdown */}
-      {(showAiJudgement || (hotdog.attestationPeriod && !isResolved)) && (
-        <View className="flex-row items-center gap-3 px-3 pb-1">
-          {showAiJudgement && (
-            <AiJudgement logId={hotdog.logId} timestamp={hotdog.timestamp} />
-          )}
-          {hotdog.attestationPeriod && !isResolved && (
-            <VotingCountdown timestamp={hotdog.timestamp} />
-          )}
+      {pending ? (
+        /* Optimistic card — confirming on-chain */
+        <View className="px-3 py-3 flex-row items-center gap-2">
+          <Text className="text-sm">⏳</Text>
+          <Text className="text-neutral/60 text-sm font-medium">
+            Posting onchain…
+          </Text>
         </View>
-      )}
+      ) : (
+        <>
+          {/* Vote bar — outside navigation pressable so taps register correctly */}
+          <VoteBar
+            logId={hotdog.logId}
+            validCount={validCount}
+            invalidCount={invalidCount}
+            userHasVoted={userHasVoted}
+            userVotedValid={userVotedValid}
+            attestationStatus={hotdog.attestationPeriod?.status}
+            onVoteSuccess={onVoteSuccess}
+          />
 
-      {/* Footer */}
-      <View className="flex-row items-center justify-between px-3 pb-3">
-        <Text className="text-xs text-neutral/40 font-mono">
-          🌭 #{hotdog.logId}
-        </Text>
-        {hotdog.zoraCoin?.marketCap && (
-          <View className="flex-row items-center gap-2">
-            {typeof hotdog.zoraCoin.uniqueHolders === "number" && (
-              <Text className="text-xs text-neutral/40">
-                {hotdog.zoraCoin.uniqueHolders} holders
-              </Text>
-            )}
-            <Text className="text-xs text-info">
-              Ξ {parseFloat(hotdog.zoraCoin.marketCap).toFixed(4)} mcap
+          {/* Meta row — AI verdict + live voting countdown */}
+          {(showAiJudgement || (hotdog.attestationPeriod && !isResolved)) && (
+            <View className="flex-row items-center gap-3 px-3 pb-1">
+              {showAiJudgement && (
+                <AiJudgement logId={hotdog.logId} timestamp={hotdog.timestamp} />
+              )}
+              {hotdog.attestationPeriod && !isResolved && (
+                <VotingCountdown timestamp={hotdog.timestamp} />
+              )}
+            </View>
+          )}
+
+          {/* Footer */}
+          <View className="flex-row items-center justify-between px-3 pb-3">
+            <Text className="text-xs text-neutral/40 font-mono">
+              🌭 #{hotdog.logId}
             </Text>
+            {hotdog.zoraCoin?.marketCap && (
+              <View className="flex-row items-center gap-2">
+                {typeof hotdog.zoraCoin.uniqueHolders === "number" && (
+                  <Text className="text-xs text-neutral/40">
+                    {hotdog.zoraCoin.uniqueHolders} holders
+                  </Text>
+                )}
+                <Text className="text-xs text-info">
+                  Ξ {parseFloat(hotdog.zoraCoin.marketCap).toFixed(4)} mcap
+                </Text>
+              </View>
+            )}
           </View>
-        )}
-      </View>
+        </>
+      )}
     </View>
   );
 }

--- a/mobile/src/components/HotdogCard.tsx
+++ b/mobile/src/components/HotdogCard.tsx
@@ -6,6 +6,8 @@ import { ProfileAvatar } from "~/components/ProfileAvatar";
 import { ProfileBadge } from "~/components/ProfileBadge";
 import { VerdictStamp } from "~/components/VerdictStamp";
 import { VoteBar } from "~/components/VoteBar";
+import { AiJudgement } from "~/components/AiJudgement";
+import { VotingCountdown } from "~/components/VotingCountdown";
 import {
   convertIpfsToHttps,
   formatTimestamp,
@@ -20,6 +22,7 @@ interface Props {
   userHasVoted: boolean;
   userVotedValid: boolean;
   onVoteSuccess?: () => void;
+  showAiJudgement?: boolean;
 }
 
 export function HotdogCard({
@@ -29,6 +32,7 @@ export function HotdogCard({
   userHasVoted,
   userVotedValid,
   onVoteSuccess,
+  showAiJudgement = false,
 }: Props) {
   const router = useRouter();
   const { width } = useWindowDimensions();
@@ -131,15 +135,34 @@ export function HotdogCard({
         onVoteSuccess={onVoteSuccess}
       />
 
+      {/* Meta row — AI verdict + live voting countdown */}
+      {(showAiJudgement || (hotdog.attestationPeriod && !isResolved)) && (
+        <View className="flex-row items-center gap-3 px-3 pb-1">
+          {showAiJudgement && (
+            <AiJudgement logId={hotdog.logId} timestamp={hotdog.timestamp} />
+          )}
+          {hotdog.attestationPeriod && !isResolved && (
+            <VotingCountdown timestamp={hotdog.timestamp} />
+          )}
+        </View>
+      )}
+
       {/* Footer */}
       <View className="flex-row items-center justify-between px-3 pb-3">
         <Text className="text-xs text-neutral/40 font-mono">
           🌭 #{hotdog.logId}
         </Text>
         {hotdog.zoraCoin?.marketCap && (
-          <Text className="text-xs text-info">
-            Ξ {parseFloat(hotdog.zoraCoin.marketCap).toFixed(4)} mcap
-          </Text>
+          <View className="flex-row items-center gap-2">
+            {typeof hotdog.zoraCoin.uniqueHolders === "number" && (
+              <Text className="text-xs text-neutral/40">
+                {hotdog.zoraCoin.uniqueHolders} holders
+              </Text>
+            )}
+            <Text className="text-xs text-info">
+              Ξ {parseFloat(hotdog.zoraCoin.marketCap).toFixed(4)} mcap
+            </Text>
+          </View>
         )}
       </View>
     </View>

--- a/mobile/src/components/HotdogCard.tsx
+++ b/mobile/src/components/HotdogCard.tsx
@@ -75,26 +75,33 @@ export function HotdogCard({
     >
       {/* Header + Image — tapping navigates to dog detail page */}
       <Pressable onPress={() => router.push(`/dog/${hotdog.logId}` as never)}>
-        {/* Header */}
+        {/* Header — tapping the eater navigates to their profile */}
         <View className="flex-row items-center p-3 gap-2">
-          <ProfileAvatar
-            image={hotdog.eaterProfile?.image}
-            address={hotdog.eater}
-            size={38}
-          />
-          <View className="flex-1">
-            <View className="flex-row items-center gap-1">
-              <Text className="font-bold text-neutral text-sm" numberOfLines={1}>
-                {eaterName}
-              </Text>
-              <ProfileBadge profile={hotdog.eaterProfile} />
+          <Pressable
+            className="flex-row items-center gap-2 flex-1"
+            onPress={() =>
+              router.push(`/profile/address/${hotdog.eater}` as never)
+            }
+          >
+            <ProfileAvatar
+              image={hotdog.eaterProfile?.image}
+              address={hotdog.eater}
+              size={38}
+            />
+            <View className="flex-1">
+              <View className="flex-row items-center gap-1">
+                <Text className="font-bold text-neutral text-sm" numberOfLines={1}>
+                  {eaterName}
+                </Text>
+                <ProfileBadge profile={hotdog.eaterProfile} />
+              </View>
+              {showVia && (
+                <Text className="text-xs text-neutral/50" numberOfLines={1}>
+                  via {loggerName}
+                </Text>
+              )}
             </View>
-            {showVia && (
-              <Text className="text-xs text-neutral/50" numberOfLines={1}>
-                via {loggerName}
-              </Text>
-            )}
-          </View>
+          </Pressable>
           <Text className="text-xs text-neutral/40">
             {formatTimestamp(hotdog.timestamp)}
           </Text>

--- a/mobile/src/components/HotdogFeed.tsx
+++ b/mobile/src/components/HotdogFeed.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
 import { FlashList } from "@shopify/flash-list";
 import { trpc } from "~/utils/trpc";
@@ -10,6 +10,7 @@ import type { GetAllResponse, ProcessedHotdog } from "~/types";
 import { buildAttestationMaps, getAttestationData } from "@shared/feed";
 import { useAuth } from "~/providers/AuthProvider";
 import { COLORS } from "~/constants/colors";
+import { usePendingDogs, pendingDogsStore } from "~/stores/pendingDogs";
 
 const PAGE_SIZE = 10;
 
@@ -23,6 +24,7 @@ export function HotdogFeed({ userAddress, header }: Props) {
   const voter = session?.address ?? ZERO_ADDRESS;
   const isMainFeed = !userAddress;
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const pending = usePendingDogs(String(CHAIN_ID));
 
   const query = trpc.hotdog.getAll.useInfiniteQuery(
     {
@@ -35,6 +37,9 @@ export function HotdogFeed({ userAddress, header }: Props) {
       keepPreviousData: true,
       getNextPageParam: (lastPage: GetAllResponse) => lastPage.nextCursor,
       refetchOnWindowFocus: false,
+      // While an optimistic card is in flight, poll so the real on-chain row
+      // lands and replaces it.
+      refetchInterval: isMainFeed && pending.length > 0 ? 6000 : false,
     },
   );
 
@@ -47,6 +52,47 @@ export function HotdogFeed({ userAddress, header }: Props) {
     () => pages.flatMap((p) => p.hotdogs),
     [pages],
   );
+
+  const loadedImageUris = useMemo(
+    () => new Set(hotdogs.map((h) => h.imageUri)),
+    [hotdogs],
+  );
+
+  // Optimistic pending cards (main feed only), deduped against real rows.
+  const pendingCards = useMemo<ProcessedHotdog[]>(() => {
+    if (!isMainFeed) return [];
+    return pending
+      .filter((p) => !loadedImageUris.has(p.imageUri))
+      .map((p) => ({
+        logId: p.logId,
+        imageUri: p.imageUri,
+        metadataUri: "",
+        timestamp: p.timestamp,
+        eater: p.eater,
+        logger: p.logger,
+        zoraCoin: null,
+        metadata: null,
+        attestationPeriod: undefined,
+        duplicateOfLogId: null,
+        eaterProfile: null,
+        loggerProfile: null,
+      }));
+  }, [isMainFeed, pending, loadedImageUris]);
+
+  const data = useMemo<ProcessedHotdog[]>(
+    () => (pendingCards.length ? [...pendingCards, ...hotdogs] : hotdogs),
+    [pendingCards, hotdogs],
+  );
+
+  // Expire stuck pending cards and drop any whose real row has now indexed.
+  useEffect(() => {
+    pendingDogsStore.clearExpired();
+    for (const p of pending) {
+      if (loadedImageUris.has(p.imageUri)) {
+        pendingDogsStore.remove(p.transactionId);
+      }
+    }
+  }, [pending, loadedImageUris]);
 
   // Build logId -> attestation lookup maps once per data change (shared helper).
   const attestationMaps = useMemo(() => buildAttestationMaps(pages), [pages]);
@@ -139,9 +185,10 @@ export function HotdogFeed({ userAddress, header }: Props) {
 
   return (
     <FlashList
-      data={hotdogs}
+      data={data}
       keyExtractor={(item) => item.logId}
       renderItem={({ item }) => {
+        const isPending = item.logId.startsWith("pending-");
         const a = getAttestationData(item.logId, attestationMaps);
         return (
           <HotdogCard
@@ -151,6 +198,7 @@ export function HotdogFeed({ userAddress, header }: Props) {
             userHasVoted={a.userAttested}
             userVotedValid={a.userAttestation}
             onVoteSuccess={refetch}
+            pending={isPending}
           />
         );
       }}

--- a/mobile/src/components/HotdogFeed.tsx
+++ b/mobile/src/components/HotdogFeed.tsx
@@ -1,10 +1,12 @@
-import React, { useCallback, useState } from "react";
-import { ActivityIndicator, Text, View } from "react-native";
+import React, { useCallback, useMemo, useState } from "react";
+import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
 import { FlashList } from "@shopify/flash-list";
 import { trpc } from "~/utils/trpc";
 import { CHAIN_ID, ZERO_ADDRESS } from "~/constants";
 import { HotdogCard } from "~/components/HotdogCard";
-import type { ProcessedHotdog } from "~/types";
+import { LeaderboardBanner } from "~/components/LeaderboardBanner";
+import type { GetAllResponse, ProcessedHotdog } from "~/types";
+import { buildAttestationMaps, getAttestationData } from "@shared/feed";
 import { useAuth } from "~/providers/AuthProvider";
 import { COLORS } from "~/constants/colors";
 
@@ -17,27 +19,96 @@ interface Props {
 
 export function HotdogFeed({ userAddress, header }: Props) {
   const { session } = useAuth();
-  const [page, setPage] = useState(0);
+  const voter = session?.address ?? ZERO_ADDRESS;
+  const isMainFeed = !userAddress;
+  const [isRefreshing, setIsRefreshing] = useState(false);
 
-  const query = trpc.hotdog.getAll.useQuery(
+  const query = trpc.hotdog.getAll.useInfiniteQuery(
     {
       chainId: CHAIN_ID,
       user: userAddress ?? ZERO_ADDRESS,
-      start: 0,
-      limit: PAGE_SIZE * (page + 1),
+      voter,
+      limit: PAGE_SIZE,
     },
-    { keepPreviousData: true },
+    {
+      keepPreviousData: true,
+      getNextPageParam: (lastPage: GetAllResponse) => lastPage.nextCursor,
+      refetchOnWindowFocus: false,
+    },
   );
+
+  const pages = useMemo(
+    () => (query.data?.pages ?? []) as GetAllResponse[],
+    [query.data?.pages],
+  );
+
+  const hotdogs = useMemo<ProcessedHotdog[]>(
+    () => pages.flatMap((p) => p.hotdogs),
+    [pages],
+  );
+
+  // Build logId -> attestation lookup maps once per data change (shared helper).
+  const attestationMaps = useMemo(() => buildAttestationMaps(pages), [pages]);
 
   const refetch = useCallback(async () => {
     await query.refetch();
   }, [query]);
 
-  const loadMore = useCallback(() => {
-    if (query.data?.hasNextPage) {
-      setPage((p) => p + 1);
+  // Manual "Refresh feed" — pulls new on-chain logs into the DB, then refetches.
+  // The backend enforces a per-identity cooldown; surface that as an alert.
+  const refreshFeed = trpc.indexer.refreshFeed.useMutation();
+  const handleRefresh = useCallback(async () => {
+    if (isRefreshing) return;
+    setIsRefreshing(true);
+    try {
+      await refreshFeed.mutateAsync({ chainId: CHAIN_ID });
+      await refetch();
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Could not refresh right now.";
+      Alert.alert("Refresh feed", message);
+    } finally {
+      setIsRefreshing(false);
     }
-  }, [query.data?.hasNextPage]);
+  }, [isRefreshing, refreshFeed, refetch]);
+
+  const loadMore = useCallback(() => {
+    if (query.hasNextPage && !query.isFetchingNextPage) {
+      void query.fetchNextPage();
+    }
+  }, [query]);
+
+  const listHeader = useMemo(() => {
+    if (!isMainFeed && !header) return undefined;
+    return (
+      <View>
+        {header}
+        {isMainFeed && (
+          <View className="px-4 pt-3 gap-3">
+            <View className="overflow-hidden rounded-2xl bg-base-100 border border-base-300">
+              <LeaderboardBanner scrollSpeed={40} />
+            </View>
+            <View className="flex-row justify-end">
+              <Pressable
+                onPress={handleRefresh}
+                disabled={isRefreshing}
+                className="flex-row items-center gap-1.5 rounded-full px-3 py-1.5"
+              >
+                {isRefreshing ? (
+                  <ActivityIndicator color={COLORS.secondary} size="small" />
+                ) : (
+                  <Text className="text-neutral/60 text-sm">↻</Text>
+                )}
+                <Text className="text-neutral/60 text-sm font-medium">
+                  Refresh feed
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+        )}
+      </View>
+    );
+  }, [isMainFeed, header, handleRefresh, isRefreshing]);
 
   if (query.isLoading && !query.data) {
     return (
@@ -54,36 +125,39 @@ export function HotdogFeed({ userAddress, header }: Props) {
         <Text className="text-error text-center text-base">
           Failed to load the feed. Pull to refresh.
         </Text>
+        <Pressable
+          onPress={refetch}
+          className="mt-4 bg-primary rounded-2xl px-6 py-3"
+        >
+          <Text className="font-display text-neutral tracking-wide">Retry</Text>
+        </Pressable>
       </View>
     );
   }
-
-  const hotdogs = (query.data?.hotdogs ?? []) as ProcessedHotdog[];
-  const validCounts = query.data?.validAttestations ?? [];
-  const invalidCounts = query.data?.invalidAttestations ?? [];
-  const userAttested = query.data?.userAttested ?? [];
-  const userAttestations = query.data?.userAttestations ?? [];
 
   return (
     <FlashList
       data={hotdogs}
       keyExtractor={(item) => item.logId}
-      renderItem={({ item, index }) => (
-        <HotdogCard
-          hotdog={item}
-          validCount={validCounts[index] ?? "0"}
-          invalidCount={invalidCounts[index] ?? "0"}
-          userHasVoted={userAttested[index] ?? false}
-          userVotedValid={userAttestations[index] ?? false}
-          onVoteSuccess={refetch}
-        />
-      )}
+      renderItem={({ item }) => {
+        const a = getAttestationData(item.logId, attestationMaps);
+        return (
+          <HotdogCard
+            hotdog={item}
+            validCount={a.validAttestations}
+            invalidCount={a.invalidAttestations}
+            userHasVoted={a.userAttested}
+            userVotedValid={a.userAttestation}
+            onVoteSuccess={refetch}
+          />
+        );
+      }}
       estimatedItemSize={520}
       onRefresh={refetch}
-      refreshing={query.isFetching && !!query.data}
+      refreshing={query.isFetching && !query.isFetchingNextPage && !!query.data}
       onEndReached={loadMore}
       onEndReachedThreshold={0.3}
-      ListHeaderComponent={header}
+      ListHeaderComponent={listHeader}
       ListEmptyComponent={
         <View className="items-center justify-center py-20">
           <Text className="text-5xl mb-3">🌭</Text>
@@ -93,9 +167,15 @@ export function HotdogFeed({ userAddress, header }: Props) {
         </View>
       }
       ListFooterComponent={
-        query.data?.hasNextPage ? (
+        query.isFetchingNextPage ? (
           <View className="py-6 items-center">
             <ActivityIndicator color={COLORS.primary} />
+          </View>
+        ) : !query.hasNextPage && hotdogs.length > 0 ? (
+          <View className="py-6 items-center">
+            <Text className="text-neutral/50 text-sm">
+              You&apos;ve reached the end of the grill.
+            </Text>
           </View>
         ) : null
       }

--- a/mobile/src/components/HotdogFeed.tsx
+++ b/mobile/src/components/HotdogFeed.tsx
@@ -5,6 +5,7 @@ import { trpc } from "~/utils/trpc";
 import { CHAIN_ID, ZERO_ADDRESS } from "~/constants";
 import { HotdogCard } from "~/components/HotdogCard";
 import { LeaderboardBanner } from "~/components/LeaderboardBanner";
+import { PreseasonBanner } from "~/components/PreseasonBanner";
 import type { GetAllResponse, ProcessedHotdog } from "~/types";
 import { buildAttestationMaps, getAttestationData } from "@shared/feed";
 import { useAuth } from "~/providers/AuthProvider";
@@ -85,6 +86,7 @@ export function HotdogFeed({ userAddress, header }: Props) {
         {header}
         {isMainFeed && (
           <View className="px-4 pt-3 gap-3">
+            <PreseasonBanner />
             <View className="overflow-hidden rounded-2xl bg-base-100 border border-base-300">
               <LeaderboardBanner scrollSpeed={40} />
             </View>

--- a/mobile/src/components/LeaderboardBanner.tsx
+++ b/mobile/src/components/LeaderboardBanner.tsx
@@ -1,0 +1,143 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Animated, Easing, Text, View } from "react-native";
+import type { LayoutChangeEvent } from "react-native";
+import { ProfileAvatar } from "~/components/ProfileAvatar";
+import { ProfileBadge } from "~/components/ProfileBadge";
+import { useLeaderboard } from "~/hooks/useLeaderboard";
+import { COLORS } from "~/constants/colors";
+import type { LeaderboardEntry } from "~/types";
+
+interface Props {
+  /** Pixels per second the ticker scrolls. */
+  scrollSpeed?: number;
+}
+
+function TickerPill({ item }: { item: LeaderboardEntry }) {
+  return (
+    <View className="flex-row items-center gap-1.5 rounded-full bg-base-200 px-3 py-1.5">
+      <Text className="font-display text-secondary text-sm">{item.rank}</Text>
+      <ProfileAvatar
+        image={item.avatarUrl}
+        address={item.address}
+        size={20}
+      />
+      <Text className="text-neutral text-sm font-medium" numberOfLines={1}>
+        {item.name}
+      </Text>
+      <ProfileBadge profile={item.profile} />
+      <Text className="font-display text-primary text-sm">
+        {item.count}🌭
+      </Text>
+    </View>
+  );
+}
+
+function LiveBadge() {
+  const pulse = useRef(new Animated.Value(1)).current;
+
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(pulse, {
+          toValue: 0.3,
+          duration: 700,
+          useNativeDriver: true,
+        }),
+        Animated.timing(pulse, {
+          toValue: 1,
+          duration: 700,
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [pulse]);
+
+  return (
+    <View className="flex-row items-center gap-1.5 border-r border-base-300 bg-base-100 px-3 h-full">
+      <Animated.View
+        style={{
+          width: 6,
+          height: 6,
+          borderRadius: 3,
+          backgroundColor: COLORS.secondary,
+          opacity: pulse,
+        }}
+      />
+      <Text className="font-display text-secondary text-xs tracking-wider">
+        LIVE
+      </Text>
+    </View>
+  );
+}
+
+/**
+ * Auto-scrolling scoreboard ticker for the top of the feed — the mobile
+ * counterpart to the web `LeaderboardBanner`. Shows the all-time top dogs and
+ * loops seamlessly by rendering two copies of the pill row.
+ */
+export function LeaderboardBanner({ scrollSpeed = 40 }: Props) {
+  const { entries, isLoading } = useLeaderboard({ limit: 10 });
+  const translateX = useRef(new Animated.Value(0)).current;
+  const [setWidth, setSetWidth] = useState(0);
+
+  useEffect(() => {
+    if (setWidth <= 0) return;
+    translateX.setValue(0);
+    const duration = (setWidth / scrollSpeed) * 1000;
+    const loop = Animated.loop(
+      Animated.timing(translateX, {
+        toValue: -setWidth,
+        duration,
+        easing: Easing.linear,
+        useNativeDriver: true,
+      }),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [setWidth, scrollSpeed, translateX]);
+
+  const onSetLayout = (e: LayoutChangeEvent) => {
+    const w = e.nativeEvent.layout.width;
+    if (w > 0 && Math.abs(w - setWidth) > 1) setSetWidth(w);
+  };
+
+  if (isLoading) {
+    return (
+      <View className="h-12 flex-row items-stretch overflow-hidden">
+        <LiveBadge />
+        <View className="flex-1 bg-base-200" />
+      </View>
+    );
+  }
+
+  if (entries.length === 0) return null;
+
+  return (
+    <View className="h-12 flex-row items-stretch overflow-hidden">
+      <LiveBadge />
+      <View className="flex-1 overflow-hidden justify-center">
+        <Animated.View
+          style={{ flexDirection: "row", transform: [{ translateX }] }}
+        >
+          {/* First (measured) copy */}
+          <View
+            className="flex-row items-center gap-2 px-2"
+            onLayout={onSetLayout}
+          >
+            {entries.map((item) => (
+              <TickerPill key={`a-${item.address}`} item={item} />
+            ))}
+          </View>
+          {/* Second copy for a seamless loop */}
+          <View className="flex-row items-center gap-2 px-2">
+            {entries.map((item) => (
+              <TickerPill key={`b-${item.address}`} item={item} />
+            ))}
+          </View>
+        </Animated.View>
+      </View>
+    </View>
+  );
+}

--- a/mobile/src/components/LeaderboardBanner.tsx
+++ b/mobile/src/components/LeaderboardBanner.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Animated, Easing, Text, View } from "react-native";
+import { Animated, Easing, Pressable, Text, View } from "react-native";
 import type { LayoutChangeEvent } from "react-native";
+import { useRouter } from "expo-router";
 import { ProfileAvatar } from "~/components/ProfileAvatar";
 import { ProfileBadge } from "~/components/ProfileBadge";
 import { useLeaderboard } from "~/hooks/useLeaderboard";
@@ -12,9 +13,18 @@ interface Props {
   scrollSpeed?: number;
 }
 
-function TickerPill({ item }: { item: LeaderboardEntry }) {
+function TickerPill({
+  item,
+  onPress,
+}: {
+  item: LeaderboardEntry;
+  onPress: () => void;
+}) {
   return (
-    <View className="flex-row items-center gap-1.5 rounded-full bg-base-200 px-3 py-1.5">
+    <Pressable
+      onPress={onPress}
+      className="flex-row items-center gap-1.5 rounded-full bg-base-200 px-3 py-1.5"
+    >
       <Text className="font-display text-secondary text-sm">{item.rank}</Text>
       <ProfileAvatar
         image={item.avatarUrl}
@@ -28,7 +38,7 @@ function TickerPill({ item }: { item: LeaderboardEntry }) {
       <Text className="font-display text-primary text-sm">
         {item.count}🌭
       </Text>
-    </View>
+    </Pressable>
   );
 }
 
@@ -78,9 +88,13 @@ function LiveBadge() {
  * loops seamlessly by rendering two copies of the pill row.
  */
 export function LeaderboardBanner({ scrollSpeed = 40 }: Props) {
+  const router = useRouter();
   const { entries, isLoading } = useLeaderboard({ limit: 10 });
   const translateX = useRef(new Animated.Value(0)).current;
   const [setWidth, setSetWidth] = useState(0);
+
+  const goToProfile = (address: string) =>
+    router.push(`/profile/address/${address}` as never);
 
   useEffect(() => {
     if (setWidth <= 0) return;
@@ -127,13 +141,21 @@ export function LeaderboardBanner({ scrollSpeed = 40 }: Props) {
             onLayout={onSetLayout}
           >
             {entries.map((item) => (
-              <TickerPill key={`a-${item.address}`} item={item} />
+              <TickerPill
+                key={`a-${item.address}`}
+                item={item}
+                onPress={() => goToProfile(item.address)}
+              />
             ))}
           </View>
           {/* Second copy for a seamless loop */}
           <View className="flex-row items-center gap-2 px-2">
             {entries.map((item) => (
-              <TickerPill key={`b-${item.address}`} item={item} />
+              <TickerPill
+                key={`b-${item.address}`}
+                item={item}
+                onPress={() => goToProfile(item.address)}
+              />
             ))}
           </View>
         </Animated.View>

--- a/mobile/src/components/LeaderboardList.tsx
+++ b/mobile/src/components/LeaderboardList.tsx
@@ -1,5 +1,13 @@
 import React, { useMemo, useState } from "react";
-import { ActivityIndicator, FlatList, Text, TextInput, View } from "react-native";
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { useRouter } from "expo-router";
 import { ProfileAvatar } from "~/components/ProfileAvatar";
 import { ProfileBadge } from "~/components/ProfileBadge";
 import { useLeaderboard } from "~/hooks/useLeaderboard";
@@ -14,6 +22,7 @@ interface Props {
 }
 
 export function LeaderboardList({ seasonOnly = true }: Props) {
+  const router = useRouter();
   const [search, setSearch] = useState("");
 
   const { startDate, endDate } = useMemo(
@@ -74,7 +83,10 @@ export function LeaderboardList({ seasonOnly = true }: Props) {
         const isPodium = rank <= 3;
 
         return (
-          <View
+          <Pressable
+            onPress={() =>
+              router.push(`/profile/address/${item.address}` as never)
+            }
             className={[
               "flex-row items-center px-4 py-3 mx-4 mb-2 rounded-2xl",
               isPodium ? "bg-base-200" : "bg-base-100",
@@ -126,7 +138,7 @@ export function LeaderboardList({ seasonOnly = true }: Props) {
                 </Text>
               </View>
             )}
-          </View>
+          </Pressable>
         );
       }}
       ListEmptyComponent={

--- a/mobile/src/components/LeaderboardList.tsx
+++ b/mobile/src/components/LeaderboardList.tsx
@@ -1,17 +1,11 @@
 import React, { useMemo, useState } from "react";
-import {
-  ActivityIndicator,
-  FlatList,
-  Text,
-  TextInput,
-  View,
-} from "react-native";
-import { trpc } from "~/utils/trpc";
-import { CHAIN_ID } from "~/constants";
+import { ActivityIndicator, FlatList, Text, TextInput, View } from "react-native";
 import { ProfileAvatar } from "~/components/ProfileAvatar";
-import { getDisplayName } from "~/utils/format";
+import { ProfileBadge } from "~/components/ProfileBadge";
+import { useLeaderboard } from "~/hooks/useLeaderboard";
 import { COLORS } from "~/constants/colors";
 import { CONTEST_START_TIME, CONTEST_END_TIME } from "~/constants";
+import type { LeaderboardEntry } from "~/types";
 
 const MEDALS = ["🥇", "🥈", "🥉"];
 
@@ -22,42 +16,36 @@ interface Props {
 export function LeaderboardList({ seasonOnly = true }: Props) {
   const [search, setSearch] = useState("");
 
-  const contestStart = useMemo(
-    () => Math.floor(new Date(CONTEST_START_TIME).getTime() / 1000),
-    [],
-  );
-  const contestEnd = useMemo(
-    () => Math.floor(new Date(CONTEST_END_TIME).getTime() / 1000),
-    [],
+  const { startDate, endDate } = useMemo(
+    () =>
+      seasonOnly
+        ? {
+            startDate: new Date(CONTEST_START_TIME),
+            endDate: new Date(CONTEST_END_TIME),
+          }
+        : { startDate: undefined, endDate: undefined },
+    [seasonOnly],
   );
 
-  const query = trpc.hotdog.getLeaderboard.useQuery({
-    chainId: CHAIN_ID,
-    ...(seasonOnly ? { startDate: contestStart, endDate: contestEnd } : {}),
+  // Fetch a deep list (not just the top 10 ticker slice) so search is useful.
+  const { entries, isLoading } = useLeaderboard({
+    startDate,
+    endDate,
+    limit: 500,
   });
 
-  const entries = useMemo(() => {
-    const users = query.data?.users ?? [];
-    const hotdogs = query.data?.hotdogs ?? [];
-    const profiles = query.data?.profiles ?? [];
-
-    const mapped = users.map((address: string, i: number) => ({
-      address,
-      count: hotdogs[i] ?? "0",
-      profile: (profiles[i] as { name?: string | null; username?: string | null; image?: string | null } | null) ?? null,
-    }));
-
-    if (!search) return mapped;
-
+  const filtered = useMemo(() => {
+    if (!search) return entries;
     const q = search.toLowerCase();
-    return mapped.filter((e) =>
-      e.address.toLowerCase().includes(q) ||
-      e.profile?.username?.toLowerCase().includes(q) ||
-      e.profile?.name?.toLowerCase().includes(q),
+    return entries.filter(
+      (e) =>
+        e.address.toLowerCase().includes(q) ||
+        e.profile?.username?.toLowerCase().includes(q) ||
+        e.profile?.name?.toLowerCase().includes(q),
     );
-  }, [query.data, search]);
+  }, [entries, search]);
 
-  if (query.isLoading) {
+  if (isLoading) {
     return (
       <View className="flex-1 items-center justify-center py-20">
         <ActivityIndicator color={COLORS.primary} size="large" />
@@ -67,8 +55,8 @@ export function LeaderboardList({ seasonOnly = true }: Props) {
 
   return (
     <FlatList
-      data={entries}
-      keyExtractor={(item: { address: string }) => item.address}
+      data={filtered}
+      keyExtractor={(item: LeaderboardEntry) => item.address}
       ListHeaderComponent={
         <View className="px-4 pt-2 pb-3">
           <TextInput
@@ -80,10 +68,9 @@ export function LeaderboardList({ seasonOnly = true }: Props) {
           />
         </View>
       }
-      renderItem={({ item, index }: { item: { address: string; count: string; profile: { name?: string | null; username?: string | null; image?: string | null } | null }; index: number }) => {
-        const rank = index + 1;
-        const name = getDisplayName(item.profile, item.address);
-        const medal = MEDALS[index] ?? null;
+      renderItem={({ item }: { item: LeaderboardEntry }) => {
+        const rank = item.rank;
+        const medal = MEDALS[rank - 1] ?? null;
         const isPodium = rank <= 3;
 
         return (
@@ -114,17 +101,20 @@ export function LeaderboardList({ seasonOnly = true }: Props) {
               )}
             </View>
             <ProfileAvatar
-              image={item.profile?.image}
+              image={item.avatarUrl}
               address={item.address}
               size={40}
             />
             <View className="flex-1 ml-3">
-              <Text
-                className="font-bold text-neutral text-sm"
-                numberOfLines={1}
-              >
-                {name}
-              </Text>
+              <View className="flex-row items-center gap-1">
+                <Text
+                  className="font-bold text-neutral text-sm"
+                  numberOfLines={1}
+                >
+                  {item.name}
+                </Text>
+                <ProfileBadge profile={item.profile} />
+              </View>
               <Text className="text-neutral/50 text-xs">
                 {item.count} dog{parseInt(item.count, 10) !== 1 ? "s" : ""}
               </Text>

--- a/mobile/src/components/LogModal.tsx
+++ b/mobile/src/components/LogModal.tsx
@@ -66,7 +66,7 @@ export function LogModal({ visible, onClose, onSuccess }: Props) {
         onSuccess?.();
       }, 1500);
     },
-    onError: (err: Error) => {
+    onError: (err) => {
       setStep("idle");
       Alert.alert("Error", err.message ?? "Failed to log dog.");
     },

--- a/mobile/src/components/LogModal.tsx
+++ b/mobile/src/components/LogModal.tsx
@@ -19,6 +19,7 @@ import { useAuth } from "~/providers/AuthProvider";
 import { CHAIN_ID } from "~/constants";
 import { COLORS } from "~/constants/colors";
 import { uploadImageToIPFS, uploadMetadataToIPFS } from "~/utils/upload";
+import { pendingDogsStore } from "~/stores/pendingDogs";
 
 interface Props {
   visible: boolean;
@@ -51,6 +52,7 @@ export function LogModal({ visible, onClose, onSuccess }: Props) {
   const successScale = useRef(new Animated.Value(0)).current;
 
   const checkSafetyMutation = trpc.hotdog.checkForSafety.useMutation();
+  const refreshFeed = trpc.indexer.refreshFeed.useMutation();
   const logMutation = trpc.hotdog.log.useMutation({
     onSuccess: () => {
       setStep("success");
@@ -132,12 +134,35 @@ export function LogModal({ visible, onClose, onSuccess }: Props) {
 
       // Log onchain via server wallet
       setStep("logging");
-      await logMutation.mutateAsync({
+      const result = await logMutation.mutateAsync({
         chainId: CHAIN_ID,
         imageUri: ipfsImageUri,
         metadataUri,
         description: description.trim() || undefined,
       });
+
+      // Optimistically show a pending card in the feed until the real on-chain
+      // row indexes (deduped by imageUri in the feed).
+      const txId: string | undefined = result?.transactionId;
+      if (txId && session.address) {
+        pendingDogsStore.add({
+          transactionId: txId,
+          logId: `pending-${txId}`,
+          imageUri: ipfsImageUri,
+          eater: session.address,
+          logger: session.address,
+          timestamp:
+            (result?.optimisticData?.timestamp as string | undefined) ??
+            String(Math.floor(Date.now() / 1000)),
+          chainId: String(CHAIN_ID),
+          isPending: true,
+        });
+        // Pull the new log into the DB so the feed's next refetch replaces the
+        // optimistic card with the real row.
+        void refreshFeed.mutateAsync({ chainId: CHAIN_ID }).catch(() => {
+          /* cooldown / offline — the feed poll will still pick it up */
+        });
+      }
     } catch (err) {
       setStep("idle");
       const msg = err instanceof Error ? err.message : "Something went wrong.";

--- a/mobile/src/components/NotificationsSettings.tsx
+++ b/mobile/src/components/NotificationsSettings.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { Switch, Text, View } from "react-native";
+import { trpc } from "~/utils/trpc";
+import { COLORS } from "~/constants/colors";
+
+interface Props {
+  address: string;
+  fid?: number | null;
+}
+
+/**
+ * Farcaster notification toggle (mobile counterpart to the web Notifications
+ * Settings). Only Farcaster-verified users can receive mini-app notifications,
+ * so it renders nothing without an fid.
+ */
+export function NotificationsSettings({ address, fid }: Props) {
+  const stateQuery = trpc.user.getNotificationState.useQuery(
+    { address },
+    { enabled: !!address, refetchOnWindowFocus: false },
+  );
+  const toggle = trpc.user.toggleNotifications.useMutation({
+    onSuccess: () => {
+      void stateQuery.refetch();
+    },
+  });
+
+  if (!fid) return null;
+
+  const enabled = Boolean(stateQuery.data);
+
+  return (
+    <View className="mt-3 bg-base-200 rounded-xl px-4 py-3 flex-row items-center justify-between">
+      <View className="flex-1 pr-3">
+        <Text className="text-neutral font-bold text-sm">🔔 Notifications</Text>
+        <Text className="text-neutral/50 text-xs">
+          Get Farcaster alerts about your dogs and verdicts.
+        </Text>
+      </View>
+      <Switch
+        value={enabled}
+        disabled={toggle.isLoading}
+        onValueChange={(v) => toggle.mutate({ enabled: v })}
+        trackColor={{ true: COLORS.accent, false: COLORS.base300 }}
+        thumbColor={COLORS.white}
+      />
+    </View>
+  );
+}

--- a/mobile/src/components/PreseasonBanner.tsx
+++ b/mobile/src/components/PreseasonBanner.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from "react";
+import { Pressable, Text, View } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { getSeasonInfo } from "@shared/season";
+
+const STORAGE_KEY = "preseason-banner-dismissed";
+
+/**
+ * Dismissible pre-season notice shown on the feed until the contest goes live —
+ * the mobile counterpart to the web PreseasonBanner.
+ */
+export function PreseasonBanner() {
+  const { isLive } = getSeasonInfo();
+  const [dismissed, setDismissed] = useState(true);
+
+  useEffect(() => {
+    void AsyncStorage.getItem(STORAGE_KEY).then((v) =>
+      setDismissed(v === "true"),
+    );
+  }, []);
+
+  if (isLive || dismissed) return null;
+
+  const dismiss = () => {
+    void AsyncStorage.setItem(STORAGE_KEY, "true");
+    setDismissed(true);
+  };
+
+  return (
+    <View className="flex-row items-center justify-between bg-primary rounded-2xl px-4 py-3">
+      <Text className="font-display text-neutral text-sm tracking-wide flex-1">
+        🌭 PRE-SEASON: Competition kicks off July 4th
+      </Text>
+      <Pressable onPress={dismiss} hitSlop={8}>
+        <Text className="text-neutral/60 text-base ml-3">✕</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/mobile/src/components/VoteBar.tsx
+++ b/mobile/src/components/VoteBar.tsx
@@ -44,7 +44,7 @@ export function VoteBar({
     onSuccess: () => {
       onVoteSuccess?.();
     },
-    onError: (err: Error) => {
+    onError: (err) => {
       const msg = err.message ?? "Failed to vote";
       if (msg.includes("Insufficient stake")) {
         Alert.alert(

--- a/mobile/src/components/VotingCountdown.tsx
+++ b/mobile/src/components/VotingCountdown.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from "react";
+import { Modal, Pressable, Text, View } from "react-native";
+import { getAttestationCountdown } from "@shared/time";
+
+interface Props {
+  /** Log unix timestamp in seconds. */
+  timestamp: string;
+}
+
+/**
+ * Live countdown for a log's 48h voting window (mobile counterpart to the web
+ * VotingCountdown), with an info sheet explaining how judging works.
+ */
+export function VotingCountdown({ timestamp }: Props) {
+  const [cd, setCd] = useState(() => getAttestationCountdown(timestamp));
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setCd(getAttestationCountdown(timestamp));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [timestamp]);
+
+  if (cd.expired) return null;
+
+  return (
+    <>
+      <Pressable
+        onPress={() => setOpen(true)}
+        className="flex-row items-center gap-1"
+      >
+        <Text className="text-neutral/40 text-xs">⏱</Text>
+        <Text className="font-mono text-xs text-neutral/50">{cd.label}</Text>
+      </Pressable>
+
+      <Modal
+        visible={open}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setOpen(false)}
+      >
+        <Pressable
+          className="flex-1 bg-black/50 items-center justify-center px-6"
+          onPress={() => setOpen(false)}
+        >
+          <View className="bg-base-100 rounded-3xl p-6 w-full max-w-md">
+            <Text className="font-display text-neutral text-2xl mb-3 tracking-wide">
+              Hotdog vs Not Hotdog
+            </Text>
+            <Text className="text-neutral/70 text-sm leading-relaxed mb-2">
+              The countdown is how long you have to judge whether this hotdog is
+              valid.
+            </Text>
+            <Text className="text-neutral/70 text-sm leading-relaxed mb-2">
+              Users moderate each other by judging if a photo should count toward
+              the contest — this prevents duplicates, fakes, and spam.
+            </Text>
+            <Text className="text-neutral/70 text-sm leading-relaxed mb-2">
+              To keep judges honest, they stake $HOTDOG. If your verdict matches
+              the majority, you earn a portion of the tokens staked by voters who
+              judged incorrectly.
+            </Text>
+            <Text className="text-neutral/60 text-sm leading-relaxed mb-5">
+              Once the timer ends, voting closes. If a submission got more yes
+              votes than no votes, it counts toward the total.
+            </Text>
+            <Pressable
+              onPress={() => setOpen(false)}
+              className="bg-primary rounded-2xl py-3 items-center"
+            >
+              <Text className="font-bold text-neutral">Got it</Text>
+            </Pressable>
+          </View>
+        </Pressable>
+      </Modal>
+    </>
+  );
+}

--- a/mobile/src/constants/index.ts
+++ b/mobile/src/constants/index.ts
@@ -1,5 +1,21 @@
 import Constants from "expo-constants";
 
+// Cross-platform constants (contest timing, attestation rules, zero address,
+// app name) come from the shared data layer so web + mobile never drift.
+export {
+  ZERO_ADDRESS,
+  CONTEST_START_TIME,
+  CONTEST_END_TIME,
+  DOG_FEED_START_TIME,
+  ATTESTATION_WINDOW_SECONDS,
+  APP_NAME,
+  APP_DESCRIPTION,
+  BASE_MAINNET_ID,
+  BASE_SEPOLIA_ID,
+} from "@shared/constants";
+
+// ---- Mobile-only runtime config ----
+
 export const API_URL =
   (Constants.expoConfig?.extra?.apiUrl as string | undefined) ??
   process.env.EXPO_PUBLIC_API_URL ??
@@ -10,20 +26,7 @@ export const THIRDWEB_CLIENT_ID =
   process.env.NEXT_PUBLIC_THIRDWEB_CLIENT_ID ??
   "";
 
-export const CHAIN_ID = parseInt(
-  process.env.EXPO_PUBLIC_CHAIN_ID ?? "8453",
-  10,
-);
-
-export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
-
-export const CONTEST_START_TIME = "2026-07-04T10:00:00-04:00";
-export const CONTEST_END_TIME = "2026-09-07T23:59:00-04:00";
-
-export const ATTESTATION_WINDOW_SECONDS = 48 * 60 * 60;
-
-export const APP_NAME = "Log a Dog";
-export const APP_DESCRIPTION = "Earn money eating hotdogs";
+export const CHAIN_ID = parseInt(process.env.EXPO_PUBLIC_CHAIN_ID ?? "8453", 10);
 
 export const FARCASTER_RELAY_URL = "https://relay.farcaster.xyz";
 export const FARCASTER_DOMAIN = "logadog.com";

--- a/mobile/src/hooks/useHotdogs.ts
+++ b/mobile/src/hooks/useHotdogs.ts
@@ -1,0 +1,79 @@
+import { trpc } from "~/utils/trpc";
+import { CHAIN_ID, ZERO_ADDRESS } from "~/constants";
+import type { ProcessedHotdog } from "~/types";
+
+/**
+ * Typed data hooks for the hotdog read endpoints. The tRPC client is currently
+ * untyped (`createTRPCReact<any>`, see utils/trpc), so these wrappers are the
+ * single place casts live — every screen consumes fully-typed results built on
+ * the shared domain types.
+ */
+
+export interface Judge {
+  voter: string;
+  correct: number;
+  incorrect: number;
+  total: number;
+  accuracy: number;
+  profile: { username?: string; imgUrl?: string; address?: string };
+}
+
+export interface UseHotdogResult {
+  hotdog?: ProcessedHotdog;
+  validAttestations: string;
+  invalidAttestations: string;
+  userAttested: boolean;
+  userAttestation: boolean;
+  isLoading: boolean;
+  refetch: () => void;
+}
+
+/** A single dog with the viewer's attestation state. */
+export function useHotdog(logId: string, voter?: string): UseHotdogResult {
+  const query = trpc.hotdog.getById.useQuery(
+    { chainId: CHAIN_ID, user: voter ?? ZERO_ADDRESS, logId },
+    { enabled: !!logId },
+  );
+  const data = query.data as
+    | {
+        hotdog?: ProcessedHotdog;
+        validAttestations?: string;
+        invalidAttestations?: string;
+        userAttested?: boolean;
+        userAttestation?: boolean;
+      }
+    | undefined;
+
+  return {
+    hotdog: data?.hotdog,
+    validAttestations: data?.validAttestations ?? "0",
+    invalidAttestations: data?.invalidAttestations ?? "0",
+    userAttested: data?.userAttested ?? false,
+    userAttestation: data?.userAttestation ?? false,
+    isLoading: Boolean(query.isLoading),
+    refetch: () => void query.refetch(),
+  };
+}
+
+/** Ranked judges by accuracy. */
+export function useJudges(): { judges: Judge[]; isLoading: boolean } {
+  const query = trpc.hotdog.getJudges.useQuery(undefined, {
+    refetchOnWindowFocus: false,
+    retry: 1,
+  });
+  return {
+    judges: (query.data as Judge[] | undefined) ?? [],
+    isLoading: Boolean(query.isLoading),
+  };
+}
+
+/** Map of logId -> the viewer's prior vote (present only if they voted). */
+export function useUserVotes(
+  voter?: string,
+): Record<string, boolean> | undefined {
+  const query = trpc.hotdog.getUserVotes.useQuery(
+    { voter: voter ?? "" },
+    { enabled: !!voter, staleTime: 60_000 },
+  );
+  return query.data as Record<string, boolean> | undefined;
+}

--- a/mobile/src/hooks/useLeaderboard.ts
+++ b/mobile/src/hooks/useLeaderboard.ts
@@ -15,11 +15,18 @@ export interface UseLeaderboardOptions {
  * query, same shared `toLeaderboardEntries` transform — so both apps derive
  * ranked entries identically.
  */
+export interface UseLeaderboardResult {
+  entries: LeaderboardEntry[];
+  isLoading: boolean;
+  isError: boolean;
+  refetch: () => void;
+}
+
 export function useLeaderboard({
   startDate,
   endDate,
   limit = 10,
-}: UseLeaderboardOptions = {}) {
+}: UseLeaderboardOptions = {}): UseLeaderboardResult {
   const query = trpc.hotdog.getLeaderboard.useQuery(
     {
       chainId: CHAIN_ID,
@@ -38,5 +45,12 @@ export function useLeaderboard({
     [query.data, limit],
   );
 
-  return { ...query, entries };
+  // The tRPC client is currently untyped (`createTRPCReact<any>`), so pull the
+  // query flags out through an explicitly typed result to keep consumers typed.
+  return {
+    entries,
+    isLoading: Boolean(query.isLoading),
+    isError: Boolean(query.isError),
+    refetch: () => void query.refetch(),
+  };
 }

--- a/mobile/src/hooks/useLeaderboard.ts
+++ b/mobile/src/hooks/useLeaderboard.ts
@@ -1,0 +1,42 @@
+import { useMemo } from "react";
+import { trpc } from "~/utils/trpc";
+import { CHAIN_ID } from "~/constants";
+import { toLeaderboardEntries } from "@shared/feed";
+import type { LeaderboardEntry, LeaderboardResponse } from "@shared/types";
+
+export interface UseLeaderboardOptions {
+  startDate?: Date;
+  endDate?: Date;
+  limit?: number;
+}
+
+/**
+ * Mobile leaderboard hook. Mirrors the web `useLeaderboardData` hook — same
+ * query, same shared `toLeaderboardEntries` transform — so both apps derive
+ * ranked entries identically.
+ */
+export function useLeaderboard({
+  startDate,
+  endDate,
+  limit = 10,
+}: UseLeaderboardOptions = {}) {
+  const query = trpc.hotdog.getLeaderboard.useQuery(
+    {
+      chainId: CHAIN_ID,
+      ...(startDate ? { startDate: Math.floor(startDate.getTime() / 1000) } : {}),
+      ...(endDate ? { endDate: Math.floor(endDate.getTime() / 1000) } : {}),
+    },
+    { refetchOnWindowFocus: false, refetchOnMount: false },
+  );
+
+  const entries = useMemo<LeaderboardEntry[]>(
+    () =>
+      toLeaderboardEntries(
+        query.data as LeaderboardResponse | undefined,
+        limit,
+      ),
+    [query.data, limit],
+  );
+
+  return { ...query, entries };
+}

--- a/mobile/src/stores/pendingDogs.ts
+++ b/mobile/src/stores/pendingDogs.ts
@@ -1,0 +1,73 @@
+import { useMemo, useSyncExternalStore } from "react";
+
+export interface PendingDog {
+  transactionId: string;
+  logId: string;
+  imageUri: string;
+  eater: string;
+  logger: string;
+  timestamp: string;
+  chainId: string;
+  isPending: true;
+  createdAt: number;
+}
+
+// Failsafe expiry for logs that never index. The feed removes a pending card the
+// moment its real on-chain row appears (dedup by imageUri), so this only needs
+// to catch stuck/failed txs — keep it generous.
+const EXPIRY_MS = 10 * 60 * 1000;
+
+let dogs: PendingDog[] = [];
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const l of listeners) l();
+}
+
+/**
+ * Tiny external store for optimistic "pending" dogs — the mobile counterpart to
+ * the web zustand `pendingTransactions` store, without adding a dependency.
+ */
+export const pendingDogsStore = {
+  add(dog: Omit<PendingDog, "createdAt">) {
+    dogs = [
+      { ...dog, createdAt: Date.now() },
+      ...dogs.filter((d) => d.transactionId !== dog.transactionId),
+    ];
+    emit();
+  },
+  remove(transactionId: string) {
+    const next = dogs.filter((d) => d.transactionId !== transactionId);
+    if (next.length !== dogs.length) {
+      dogs = next;
+      emit();
+    }
+  },
+  clearExpired() {
+    const now = Date.now();
+    const next = dogs.filter((d) => now - d.createdAt < EXPIRY_MS);
+    if (next.length !== dogs.length) {
+      dogs = next;
+      emit();
+    }
+  },
+  subscribe(listener: () => void) {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+  getSnapshot() {
+    return dogs;
+  },
+};
+
+/** Subscribe to pending dogs for a chain. Stable reference while unchanged. */
+export function usePendingDogs(chainId: string): PendingDog[] {
+  const all = useSyncExternalStore(
+    pendingDogsStore.subscribe,
+    pendingDogsStore.getSnapshot,
+    pendingDogsStore.getSnapshot,
+  );
+  return useMemo(() => all.filter((d) => d.chainId === chainId), [all, chainId]);
+}

--- a/mobile/src/types/index.ts
+++ b/mobile/src/types/index.ts
@@ -1,83 +1,18 @@
-export interface HotdogProfile {
-  name?: string | null;
-  username?: string | null;
-  image?: string | null;
-  fid?: number | null;
-  isKnownSpammer?: boolean | null;
-  isReportedForSpam?: boolean | null;
-  isDisqualified?: boolean | null;
-}
-
-export interface AttestationPeriod {
-  startTime: string;
-  endTime: string;
-  status: number;
-  totalValidStake: string;
-  totalInvalidStake: string;
-  isValid: boolean;
-}
-
-export interface ZoraCoinDetails {
-  id: string;
-  name: string;
-  description: string;
-  address: string;
-  symbol: string;
-  totalSupply: string;
-  totalVolume: string;
-  volume24h?: string;
-  marketCap?: string;
-  marketCapDelta24h?: string;
-  chainId?: number;
-  uniqueHolders?: number;
-  mediaContent?: {
-    mimeType?: string;
-    originalUri?: string;
-    previewImage?: {
-      small?: string;
-      medium?: string;
-      blurhash?: string;
-    };
-  };
-  link?: string;
-}
-
-export interface ProcessedHotdog {
-  logId: string;
-  imageUri: string;
-  metadataUri: string;
-  timestamp: string;
-  eater: string;
-  logger: string;
-  zoraCoin: ZoraCoinDetails | null;
-  metadata: { imageUri: string; eater: string; zoraCoin?: { address: string; name: string; symbol: string } } | null;
-  attestationPeriod?: AttestationPeriod;
-  duplicateOfLogId?: string | null;
-  eaterProfile?: HotdogProfile | null;
-  loggerProfile?: HotdogProfile | null;
-}
-
-export interface GetAllResponse {
-  hotdogs: ProcessedHotdog[];
-  validAttestations: string[];
-  invalidAttestations: string[];
-  userAttested: boolean[];
-  userAttestations: boolean[];
-  totalPages: number;
-  hasNextPage: boolean;
-}
-
-export interface LeaderboardEntry {
-  address: string;
-  count: string;
-  profile?: HotdogProfile | null;
-}
-
-export interface Session {
-  address: string;
-  sessionToken: string;
-  fid?: number | null;
-  username?: string | null;
-  image?: string | null;
-  name?: string | null;
-}
+/**
+ * Domain types now live in the shared data layer (`@shared/types`) so the web
+ * and mobile apps render the same shapes. Re-exported here to preserve existing
+ * `~/types` import paths.
+ */
+export type {
+  HotdogProfile,
+  AttestationPeriod,
+  ZoraCoinMediaContent,
+  ZoraCoinDetails,
+  HotdogMetadata,
+  ProcessedHotdog,
+  GetAllResponse,
+  LeaderboardProfile,
+  LeaderboardResponse,
+  LeaderboardEntry,
+  Session,
+} from "@shared/types";

--- a/mobile/src/utils/format.ts
+++ b/mobile/src/utils/format.ts
@@ -1,72 +1,15 @@
-export function formatTimestamp(timestamp: string): string {
-  const date = new Date(Number(timestamp) * 1000);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffSecs = Math.floor(diffMs / 1000);
-
-  if (diffSecs < 60) return `${diffSecs}s`;
-  if (diffSecs < 3600) return `${Math.floor(diffSecs / 60)}m`;
-  if (diffSecs < 86400) return `${Math.floor(diffSecs / 3600)}h`;
-  if (diffSecs < 604800) return `${Math.floor(diffSecs / 86400)}d`;
-  return date.toLocaleDateString();
-}
-
-export function formatAddress(address: string): string {
-  if (!address || address.length < 10) return address;
-  return `${address.slice(0, 6)}…${address.slice(-4)}`;
-}
-
-export function formatStake(stakeWei: string): string {
-  const num = BigInt(stakeWei);
-  const millions = Number(num) / 1e24;
-  if (millions >= 1000) return `${(millions / 1000).toFixed(1)}B`;
-  if (millions >= 1) return `${millions.toFixed(1)}M`;
-  const thousands = Number(num) / 1e21;
-  if (thousands >= 1) return `${thousands.toFixed(1)}K`;
-  return stakeWei;
-}
-
-export function getDisplayName(
-  profile?: {
-    name?: string | null;
-    username?: string | null;
-  } | null,
-  address?: string,
-): string {
-  if (profile?.name) return profile.name;
-  if (profile?.username) return `@${profile.username}`;
-  if (address) return formatAddress(address);
-  return "Unknown";
-}
-
-export function isInAttestationWindow(
-  startTime: string,
-  endTime: string,
-): boolean {
-  const now = Date.now() / 1000;
-  const start = Number(startTime);
-  const end = Number(endTime);
-  return now >= start && now <= end;
-}
-
-export function getVotePct(
-  validStr: string,
-  invalidStr: string,
-): { validPct: number; invalidPct: number } {
-  const valid = Number(validStr);
-  const invalid = Number(invalidStr);
-  const total = valid + invalid;
-  if (total === 0) return { validPct: 50, invalidPct: 50 };
-  return {
-    validPct: Math.round((valid / total) * 100),
-    invalidPct: Math.round((invalid / total) * 100),
-  };
-}
-
-export function convertIpfsToHttps(url: string | null | undefined): string | null {
-  if (!url) return null;
-  if (url.startsWith("ipfs://")) {
-    return url.replace("ipfs://", "https://ipfs.io/ipfs/");
-  }
-  return url;
-}
+/**
+ * Formatting helpers now live in the shared data layer (`@shared/format`) so the
+ * web and mobile apps stay in sync. This module re-exports them to keep the
+ * existing `~/utils/format` import paths working.
+ */
+export {
+  formatTimestamp,
+  formatAddress,
+  formatStake,
+  getDisplayName,
+  isInAttestationWindow,
+  getVotePct,
+  convertIpfsToHttps,
+  formatAbbreviatedFiat,
+} from "@shared/format";

--- a/mobile/src/utils/trpc.ts
+++ b/mobile/src/utils/trpc.ts
@@ -2,9 +2,13 @@ import { createTRPCReact } from "@trpc/react-query";
 import { httpBatchLink } from "@trpc/client";
 import superjson from "superjson";
 import { API_URL } from "~/constants";
+// AppRouter type comes from a generated, self-contained declaration bundle
+// (mobile/api-types, produced by `bun run build:api-types` at the repo root).
+// It's a type-only import, so Metro/Babel erases it — the app bundles and runs
+// without the bundle present; only `tsc` needs it (CI generates it first).
+import type { AppRouter } from "@apiTypes/src/server/api/root";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const trpc = createTRPCReact<any>();
+export const trpc = createTRPCReact<AppRouter>();
 
 export function buildTRPCClient(sessionToken?: string | null) {
   return trpc.createClient({

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -12,6 +12,9 @@
       ],
       "@shared/*": [
         "../shared/*"
+      ],
+      "@apiTypes/*": [
+        "./api-types/*"
       ]
     },
     "skipLibCheck": true

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -6,6 +6,12 @@
     "paths": {
       "~/*": [
         "./src/*"
+      ],
+      "@shared": [
+        "../shared/index.ts"
+      ],
+      "@shared/*": [
+        "../shared/*"
       ]
     },
     "skipLibCheck": true

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "dev": "next dev",
     "postinstall": "prisma generate",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit",
+    "build:api-types": "tsc -p tsconfig.api-types.json && tsc-alias -p tsconfig.api-types.json",
     "start": "next start",
     "script:fix-addresses": "tsx src/scripts/fix-address-case.ts",
     "script:migrate-events": "tsx src/scripts/migrate-dog-events.ts",
@@ -83,6 +85,7 @@
     "prettier-plugin-tailwindcss": "^0.5.14",
     "prisma": "^5.22.0",
     "tailwindcss": "^3.4.19",
+    "tsc-alias": "^1.8.17",
     "typescript": "^5.9.3"
   },
   "overrides": {

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -1,0 +1,24 @@
+/**
+ * Cross-platform constants shared by web and mobile. Values here are the single
+ * source of truth for contest timing and attestation rules; each app re-exports
+ * them from its own constants module.
+ *
+ * No runtime deps — safe for both webpack and Metro.
+ */
+
+export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+export const CONTEST_START_TIME = "2026-07-04T10:00:00-04:00";
+export const CONTEST_END_TIME = "2026-09-07T23:59:00-04:00";
+// Pre-season logs are visible and judgeable for testing, but leaderboard
+// season scoring still starts at CONTEST_START_TIME.
+export const DOG_FEED_START_TIME = "2026-06-14T00:00:00-04:00";
+
+export const ATTESTATION_WINDOW_SECONDS = 48 * 60 * 60;
+
+export const APP_NAME = "Log a Dog";
+export const APP_DESCRIPTION = "Earn money eating hotdogs";
+
+/** Chain ids used across the stack. */
+export const BASE_MAINNET_ID = 8453;
+export const BASE_SEPOLIA_ID = 84532;

--- a/shared/feed.ts
+++ b/shared/feed.ts
@@ -1,0 +1,126 @@
+/**
+ * Pure, framework-agnostic helpers for the hotdog feed. Extracted so the web and
+ * mobile feeds derive per-card attestation state and leaderboard ticker items
+ * from the same logic instead of duplicating it.
+ */
+import type {
+  GetAllResponse,
+  LeaderboardEntry,
+  LeaderboardResponse,
+} from "./types";
+import { formatAddress } from "./format";
+
+export interface AttestationMaps {
+  validMap: Record<string, string>;
+  invalidMap: Record<string, string>;
+  userAttestedMap: Record<string, boolean>;
+  userAttestationMap: Record<string, boolean>;
+}
+
+export interface AttestationData {
+  validAttestations: string;
+  invalidAttestations: string;
+  userAttested: boolean;
+  userAttestation: boolean;
+}
+
+const EMPTY_MAPS: AttestationMaps = {
+  validMap: {},
+  invalidMap: {},
+  userAttestedMap: {},
+  userAttestationMap: {},
+};
+
+/**
+ * Build logId -> attestation lookup maps from one or more feed pages. Doing this
+ * once per data change (instead of scanning arrays per card) keeps large feeds
+ * cheap to re-render.
+ */
+export function buildAttestationMaps(
+  pages: Array<Pick<
+    GetAllResponse,
+    | "hotdogs"
+    | "validAttestations"
+    | "invalidAttestations"
+    | "userAttested"
+    | "userAttestations"
+  >>,
+): AttestationMaps {
+  if (!pages || pages.length === 0) return { ...EMPTY_MAPS };
+
+  const maps: AttestationMaps = {
+    validMap: {},
+    invalidMap: {},
+    userAttestedMap: {},
+    userAttestationMap: {},
+  };
+
+  for (const page of pages) {
+    page.hotdogs.forEach((hotdog, index) => {
+      maps.validMap[hotdog.logId] = page.validAttestations?.[index] ?? "0";
+      maps.invalidMap[hotdog.logId] = page.invalidAttestations?.[index] ?? "0";
+      maps.userAttestedMap[hotdog.logId] = page.userAttested?.[index] ?? false;
+      maps.userAttestationMap[hotdog.logId] =
+        page.userAttestations?.[index] ?? false;
+    });
+  }
+
+  return maps;
+}
+
+/** Look up a single hotdog's attestation state from prebuilt maps. */
+export function getAttestationData(
+  logId: string,
+  maps: AttestationMaps,
+): AttestationData {
+  return {
+    validAttestations: maps.validMap[logId] ?? "0",
+    invalidAttestations: maps.invalidMap[logId] ?? "0",
+    userAttested: maps.userAttestedMap[logId] ?? false,
+    userAttestation: maps.userAttestationMap[logId] ?? false,
+  };
+}
+
+/**
+ * Highest numeric logId seen so far. Used to infer the next on-chain id for an
+ * optimistic card so it can display "#<next>" before the real row indexes.
+ */
+export function inferNextLogIdBase(logIds: string[]): bigint {
+  let max = 0n;
+  for (const logId of logIds) {
+    try {
+      const id = BigInt(logId);
+      if (id > max) max = id;
+    } catch {
+      // non-numeric — skip
+    }
+  }
+  return max;
+}
+
+/**
+ * Flatten leaderboard router output into ranked ticker/list entries used by the
+ * scoreboard banner and leaderboard screens.
+ */
+export function toLeaderboardEntries(
+  leaderboard: LeaderboardResponse | null | undefined,
+  limit = 10,
+): LeaderboardEntry[] {
+  if (!leaderboard) return [];
+  const users = leaderboard.users?.slice(0, limit) ?? [];
+  const hotdogs = leaderboard.hotdogs ?? [];
+  const profiles = leaderboard.profiles ?? [];
+
+  return users.map((address, i) => {
+    const profile = profiles[i];
+    return {
+      address,
+      count: String(hotdogs[i] ?? "0"),
+      rank: i + 1,
+      name:
+        profile?.name ?? profile?.username ?? formatAddress(address),
+      avatarUrl: profile?.image,
+      profile: profile ?? null,
+    };
+  });
+}

--- a/shared/format.ts
+++ b/shared/format.ts
@@ -1,0 +1,89 @@
+/**
+ * Platform-agnostic formatting + display helpers shared by web and mobile.
+ * No React / RN / Node imports so both bundlers can consume it.
+ */
+
+/** Relative "time ago" label (e.g. "5m", "3h", "2d") from a unix-seconds string. */
+export function formatTimestamp(timestamp: string | number): string {
+  const date = new Date(Number(timestamp) * 1000);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSecs = Math.floor(diffMs / 1000);
+
+  if (diffSecs < 60) return `${Math.max(diffSecs, 0)}s`;
+  if (diffSecs < 3600) return `${Math.floor(diffSecs / 60)}m`;
+  if (diffSecs < 86400) return `${Math.floor(diffSecs / 3600)}h`;
+  if (diffSecs < 604800) return `${Math.floor(diffSecs / 86400)}d`;
+  return date.toLocaleDateString();
+}
+
+/** Truncated 0x address, e.g. 0x1234…abcd. */
+export function formatAddress(address?: string | null): string {
+  if (!address || address.length < 10) return address ?? "";
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+/** Human-readable HOTDOG stake amount from a wei string (18 decimals). */
+export function formatStake(stakeWei: string): string {
+  const num = BigInt(stakeWei);
+  const millions = Number(num) / 1e24;
+  if (millions >= 1000) return `${(millions / 1000).toFixed(1)}B`;
+  if (millions >= 1) return `${millions.toFixed(1)}M`;
+  const thousands = Number(num) / 1e21;
+  if (thousands >= 1) return `${thousands.toFixed(1)}K`;
+  return stakeWei;
+}
+
+/** Preferred display name for a profile, falling back to a truncated address. */
+export function getDisplayName(
+  profile?: { name?: string | null; username?: string | null } | null,
+  address?: string,
+): string {
+  if (profile?.name) return profile.name;
+  if (profile?.username) return `@${profile.username}`;
+  if (address) return formatAddress(address);
+  return "Unknown";
+}
+
+/** Whether `now` falls inside an attestation/voting window (unix-seconds strings). */
+export function isInAttestationWindow(
+  startTime: string,
+  endTime: string,
+  now: number = Date.now() / 1000,
+): boolean {
+  const start = Number(startTime);
+  const end = Number(endTime);
+  return now >= start && now <= end;
+}
+
+/** Split valid/invalid stake counts into rounded percentages that sum to ~100. */
+export function getVotePct(
+  validStr: string,
+  invalidStr: string,
+): { validPct: number; invalidPct: number } {
+  const valid = Number(validStr);
+  const invalid = Number(invalidStr);
+  const total = valid + invalid;
+  if (total === 0) return { validPct: 50, invalidPct: 50 };
+  const validPct = Math.round((valid / total) * 100);
+  return { validPct, invalidPct: 100 - validPct };
+}
+
+/** Normalize an ipfs:// URI to a public gateway https URL. */
+export function convertIpfsToHttps(
+  url: string | null | undefined,
+): string | null {
+  if (!url) return null;
+  if (url.startsWith("ipfs://")) {
+    return url.replace("ipfs://", "https://ipfs.io/ipfs/");
+  }
+  return url;
+}
+
+/** Abbreviated fiat/number label, e.g. 1.2K / 3.4M / 5.6B. */
+export function formatAbbreviatedFiat(amount: number): string {
+  if (amount < 1000) return amount.toFixed(2);
+  if (amount < 1_000_000) return (amount / 1000).toFixed(2) + "K";
+  if (amount < 1_000_000_000) return (amount / 1_000_000).toFixed(2) + "M";
+  return (amount / 1_000_000_000).toFixed(2) + "B";
+}

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared data layer for Log a Dog — consumed by both the web (Next.js) and
+ * mobile (Expo) apps via the `@shared/*` path alias.
+ *
+ * Everything here is pure TypeScript (no React / RN / Node deps) so it can be
+ * bundled by webpack and Metro alike. UI, tRPC client instances, and platform
+ * wiring live in each app; this layer holds the types, formatting, constants,
+ * and pure data transforms they share.
+ */
+export * from "./types";
+export * from "./format";
+export * from "./constants";
+export * from "./season";
+export * from "./feed";

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -12,3 +12,4 @@ export * from "./format";
 export * from "./constants";
 export * from "./season";
 export * from "./feed";
+export * from "./time";

--- a/shared/season.ts
+++ b/shared/season.ts
@@ -1,0 +1,35 @@
+import { CONTEST_START_TIME, CONTEST_END_TIME } from "./constants";
+
+// The current competitive season. Season 4 opens on CONTEST_START_TIME.
+export const CURRENT_SEASON = 4;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export type SeasonInfo = {
+  season: number;
+  /** 1-indexed day number within the current contest window. */
+  day: number;
+  /** Whether the contest window is currently open. */
+  isLive: boolean;
+};
+
+/**
+ * Derive the season + day-of-season for the scoreboard header. Day is clamped
+ * to the contest window so it never reads before day 1 or past the finale.
+ */
+export function getSeasonInfo(now: Date = new Date()): SeasonInfo {
+  const start = new Date(CONTEST_START_TIME).getTime();
+  const end = new Date(CONTEST_END_TIME).getTime();
+  const t = now.getTime();
+
+  const isLive = t >= start && t <= end;
+  const elapsed = Math.floor(
+    (Math.min(Math.max(t, start), end) - start) / MS_PER_DAY,
+  );
+
+  return {
+    season: CURRENT_SEASON,
+    day: elapsed + 1,
+    isLive,
+  };
+}

--- a/shared/time.ts
+++ b/shared/time.ts
@@ -1,0 +1,63 @@
+import { ATTESTATION_WINDOW_SECONDS } from "./constants";
+
+export interface Countdown {
+  hours: number;
+  minutes: number;
+  seconds: number;
+  totalSeconds: number;
+  expired: boolean;
+  /** e.g. "5h 3m 12s" or "Expired". */
+  label: string;
+}
+
+/**
+ * Time left in an attestation/voting window for a log, given its unix-seconds
+ * timestamp. Shared by web and mobile so both count down identically.
+ */
+export function getAttestationCountdown(
+  timestamp: string | number,
+  windowSeconds: number = ATTESTATION_WINDOW_SECONDS,
+  now: number = Math.floor(Date.now() / 1000),
+): Countdown {
+  const end = Number(timestamp) + windowSeconds;
+  const diff = end - now;
+
+  if (diff <= 0) {
+    return {
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+      totalSeconds: 0,
+      expired: true,
+      label: "Expired",
+    };
+  }
+
+  const hours = Math.floor(diff / 3600);
+  const minutes = Math.floor((diff % 3600) / 60);
+  const seconds = diff % 60;
+
+  return {
+    hours,
+    minutes,
+    seconds,
+    totalSeconds: diff,
+    expired: false,
+    label: `${hours}h ${minutes}m ${seconds}s`,
+  };
+}
+
+/**
+ * Whether a log is still inside its voting window and not yet resolved — the
+ * shared predicate the judge queues on web and mobile use.
+ */
+export function isJudgeable(
+  timestamp: string | number,
+  attestationStatus: number | undefined,
+  windowSeconds: number = ATTESTATION_WINDOW_SECONDS,
+  now: number = Math.floor(Date.now() / 1000),
+): boolean {
+  const open = !getAttestationCountdown(timestamp, windowSeconds, now).expired;
+  const unresolved = attestationStatus !== 1;
+  return open && unresolved;
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,0 +1,124 @@
+/**
+ * Canonical, platform-agnostic domain types shared by the web (Next.js) and
+ * mobile (Expo) apps. These mirror the shapes returned by the tRPC `hotdog`
+ * router so both clients can render the same data without redeclaring types.
+ *
+ * Keep this file free of any React / React Native / Node imports so it can be
+ * bundled by both webpack (web) and Metro (mobile).
+ */
+
+export interface HotdogProfile {
+  address?: string;
+  name?: string | null;
+  username?: string | null;
+  image?: string | null;
+  fid?: number | null;
+  isKnownSpammer?: boolean | null;
+  isReportedForSpam?: boolean | null;
+  isDisqualified?: boolean | null;
+}
+
+export interface AttestationPeriod {
+  startTime: string;
+  endTime: string;
+  status: number;
+  totalValidStake: string;
+  totalInvalidStake: string;
+  isValid: boolean;
+}
+
+export interface ZoraCoinMediaContent {
+  mimeType?: string;
+  originalUri?: string;
+  previewImage?: {
+    small?: string;
+    medium?: string;
+    blurhash?: string;
+  };
+}
+
+export interface ZoraCoinDetails {
+  id: string;
+  name: string;
+  description: string;
+  address: string;
+  symbol: string;
+  totalSupply: string;
+  totalVolume: string;
+  volume24h?: string;
+  createdAt?: string;
+  creatorAddress?: string;
+  marketCap?: string;
+  marketCapDelta24h?: string;
+  chainId?: number;
+  uniqueHolders?: number;
+  mediaContent?: ZoraCoinMediaContent;
+  link?: string;
+}
+
+export interface HotdogMetadata {
+  imageUri: string;
+  eater: string;
+  zoraCoin?: { address: string; name: string; symbol: string };
+}
+
+export interface ProcessedHotdog {
+  logId: string;
+  imageUri: string;
+  metadataUri: string;
+  timestamp: string;
+  eater: string;
+  logger: string;
+  zoraCoin: ZoraCoinDetails | null;
+  metadata: HotdogMetadata | null;
+  attestationPeriod?: AttestationPeriod;
+  duplicateOfLogId?: string | null;
+  eaterProfile?: HotdogProfile | null;
+  loggerProfile?: HotdogProfile | null;
+}
+
+export interface GetAllResponse {
+  hotdogs: ProcessedHotdog[];
+  validAttestations: string[];
+  invalidAttestations: string[];
+  userAttested: boolean[];
+  userAttestations: boolean[];
+  totalPages: number;
+  hasNextPage: boolean;
+  nextCursor?: number;
+}
+
+export interface LeaderboardProfile {
+  address: string;
+  name?: string | null;
+  username?: string | null;
+  image?: string | null;
+  fid?: number | null;
+  isKnownSpammer?: boolean | null;
+  isReportedForSpam?: boolean | null;
+  isDisqualified?: boolean | null;
+}
+
+export interface LeaderboardResponse {
+  users: string[];
+  hotdogs: string[];
+  profiles: LeaderboardProfile[];
+}
+
+export interface LeaderboardEntry {
+  address: string;
+  count: string;
+  rank: number;
+  name: string;
+  avatarUrl?: string | null;
+  profile?: LeaderboardProfile | null;
+}
+
+export interface Session {
+  address: string;
+  sessionToken: string;
+  fid?: number | null;
+  username?: string | null;
+  image?: string | null;
+  name?: string | null;
+}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,17 +3,19 @@ import { parseEther } from "viem";
 export * from "./addresses";
 export * from "./chains";
 
-export const CONTEST_START_TIME = "2026-07-04T10:00:00-04:00"
-export const CONTEST_END_TIME = "2026-09-07T23:59:00-04:00"
-// Pre-season logs are visible and judgeable for testing, but leaderboard
-// season scoring still starts at CONTEST_START_TIME.
-export const DOG_FEED_START_TIME = "2026-06-14T00:00:00-04:00"
+// Contest timing + attestation rules are shared with the mobile app via the
+// cross-platform data layer so the two never drift.
+export {
+  CONTEST_START_TIME,
+  CONTEST_END_TIME,
+  // Pre-season logs are visible and judgeable for testing, but leaderboard
+  // season scoring still starts at CONTEST_START_TIME.
+  DOG_FEED_START_TIME,
+  ATTESTATION_WINDOW_SECONDS,
+  APP_NAME,
+  APP_DESCRIPTION,
+} from "@shared/constants";
 
 export const MINIMUM_STAKE = parseEther("300000");
 
-export const APP_NAME = "Log a Dog";
-export const APP_DESCRIPTION = `Earn money eating hotdogs`;
-
 export const DEFAULT_UPLOAD_PHRASE = '📷 Take a picture of you eating it!';
-
-export const ATTESTATION_WINDOW_SECONDS = 48 * 60 * 60;

--- a/src/helpers/formatFiat.ts
+++ b/src/helpers/formatFiat.ts
@@ -1,11 +1,2 @@
-export const formatAbbreviatedFiat = (amount: number) => {
-  if (amount < 1000) {
-    return amount.toFixed(2);
-  } else if (amount < 1000000) {
-    return (amount / 1000).toFixed(2) + "K";
-  } else if (amount < 1000000000) {
-    return (amount / 1000000).toFixed(2) + "M";
-  } else {
-    return (amount / 1000000000).toFixed(2) + "B";
-  }
-};
+// Shared with the mobile app via the cross-platform data layer.
+export { formatAbbreviatedFiat } from "@shared/format";

--- a/src/helpers/season.ts
+++ b/src/helpers/season.ts
@@ -1,33 +1,4 @@
-import { CONTEST_START_TIME, CONTEST_END_TIME } from "~/constants";
-
-// The current competitive season. Season 4 opens on CONTEST_START_TIME.
-export const CURRENT_SEASON = 4;
-
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
-
-export type SeasonInfo = {
-  season: number;
-  /** 1-indexed day number within the current contest window. */
-  day: number;
-  /** Whether the contest window is currently open. */
-  isLive: boolean;
-};
-
-/**
- * Derive the season + day-of-season for the scoreboard header. Day is clamped
- * to the contest window so it never reads before day 1 or past the finale.
- */
-export function getSeasonInfo(now: Date = new Date()): SeasonInfo {
-  const start = new Date(CONTEST_START_TIME).getTime();
-  const end = new Date(CONTEST_END_TIME).getTime();
-  const t = now.getTime();
-
-  const isLive = t >= start && t <= end;
-  const elapsed = Math.floor((Math.min(Math.max(t, start), end) - start) / MS_PER_DAY);
-
-  return {
-    season: CURRENT_SEASON,
-    day: elapsed + 1,
-    isLive,
-  };
-}
+// Season logic lives in the shared data layer so web + mobile compute the
+// scoreboard header identically. Re-exported to keep `~/helpers/season`
+// import paths working.
+export { CURRENT_SEASON, getSeasonInfo, type SeasonInfo } from "@shared/season";

--- a/src/server/api/routers/hotdog.ts
+++ b/src/server/api/routers/hotdog.ts
@@ -60,7 +60,7 @@ interface ZoraCoin {
   symbol: string;
 }
 
-interface ZoraCoinDetails {
+export interface ZoraCoinDetails {
   id: string;
   name: string;
   description: string;
@@ -87,7 +87,7 @@ interface ZoraCoinDetails {
   link?: string;
 }
 
-interface HotdogMetadata {
+export interface HotdogMetadata {
   imageUri: string;
   eater: string;
   zoraCoin?: ZoraCoin;
@@ -109,7 +109,7 @@ interface HotdogResponse {
   userAttestations: boolean[];
 }
 
-interface ProcessedHotdog {
+export interface ProcessedHotdog {
   logId: string;
   imageUri: string;
   metadataUri: string;
@@ -147,7 +147,7 @@ interface ProcessedHotdog {
   } | null;
 }
 
-interface GetAllResponse {
+export interface GetAllResponse {
   hotdogs: ProcessedHotdog[];
   validAttestations: string[];
   invalidAttestations: string[];

--- a/tsconfig.api-types.json
+++ b/tsconfig.api-types.json
@@ -1,0 +1,16 @@
+{
+  "//": "Emits a self-contained .d.ts bundle of the tRPC AppRouter into mobile/api-types so the Expo app can type its tRPC client without pulling web server SOURCE into its typecheck. Run via `bun run build:api-types` (tsc emit + tsc-alias rewrites the ~ aliases to relative paths). Requires the Prisma client to be generated first.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "skipLibCheck": true,
+    "incremental": false,
+    "composite": false,
+    "rootDir": ".",
+    "outDir": "mobile/api-types"
+  },
+  "include": ["src/server/api/root.ts"],
+  "exclude": ["node_modules", "contracts", "mobile"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,9 @@
     /* Path Aliases */
     "baseUrl": ".",
     "paths": {
-      "~/*": ["./src/*"]
+      "~/*": ["./src/*"],
+      "@shared": ["./shared/index.ts"],
+      "@shared/*": ["./shared/*"]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary

Brings the Expo mobile app to feature/design parity with the web app, on a **shared data layer**, and adds a **build-system change** so the mobile app's tRPC client is fully typed against the server's `AppRouter` — gated by a new **CI** workflow.

### Shared data layer (`shared/`)
Platform-agnostic, dependency-free TypeScript consumed by both apps via `@shared` (tsconfig paths for web/tsc; Metro `resolveRequest` alias for Expo): domain `types`, `format`, `constants`, `season`, `time` (countdown/`isJudgeable`), and `feed` transforms (attestation maps, leaderboard entries). Web now sources its contest constants, season logic, and `formatFiat` from it.

### Mobile feature parity
- Feed: infinite scroll, auto-scrolling leaderboard ticker, refresh-feed, preseason banner, optimistic pending cards after logging.
- Cards/detail: AI verdict badge, live voting countdown, richer Zora stats (mcap/24h/holders) + Trade/View, read-only comments (posting hands off to web — comments are user-wallet-signed and mobile uses the server wallet).
- Judging: countdown + AI on the card, shared `isJudgeable` queue, Top Judges ranking.
- Earn: live staking APY + season day; FAQ + POIDH entry points.
- New screens: public profile (`/profile/address/[address]`), FAQ, POIDH campaign — ticker pills, leaderboard rows, judge rows, and card authors all navigate to profiles.
- Profile: Farcaster notifications toggle.

### Build-system change: typed tRPC on mobile
- `tsconfig.api-types.json` + `build:api-types` emit a **self-contained `AppRouter` declaration bundle** into `mobile/api-types` (`tsc --emitDeclarationOnly`), then `tsc-alias` rewrites the `~`/`@shared` aliases to relative paths so it resolves standalone (gitignored).
- Mobile client is now `createTRPCReact<AppRouter>()` importing the type from `@apiTypes` — a **type-only import**, so Metro/Babel erases it; the app still bundles and runs without the generated files. Server-only type packages the bundle references resolve from the root `node_modules` via upward module resolution, so no workspace change is needed and the Vercel web build is untouched.
- This avoids pulling web **server source** into the mobile typecheck.

### CI (`.github/workflows/ci.yml`)
The repo had no CI. New workflow on PRs/`main`: install web deps (+ Prisma generate), **typecheck web + shared**, **build the API types bundle**, install mobile deps, **typecheck mobile**.

## Verification
The shared layer and mobile app were checked locally with `tsc --noEmit` (deps installed). The web typecheck and the `build:api-types` declaration emit require a fully generated Prisma client, which the sandbox couldn't download — **CI is the authoritative check** for those, per the workflow above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCXnAQrLBVQoLZ62ayqFFX)_