### PR TITLE
Fix mobile judge and auth flows

### DIFF
--- a/.github/workflows/eas-preview-builds.yml
+++ b/.github/workflows/eas-preview-builds.yml
@@ -54,5 +54,9 @@ jobs:
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           EXPO_PUBLIC_API_URL: https://logadog.xyz
+          EXPO_PUBLIC_APP_URL: https://logadog.xyz
+          EXPO_PUBLIC_APP_DOMAIN: logadog.xyz
+          EXPO_PUBLIC_FARCASTER_SIWE_URI: https://logadog.xyz/login
+          EXPO_PUBLIC_THIRDWEB_CLIENT_ID: ${{ secrets.EXPO_PUBLIC_THIRDWEB_CLIENT_ID || secrets.NEXT_PUBLIC_THIRDWEB_CLIENT_ID || vars.EXPO_PUBLIC_THIRDWEB_CLIENT_ID || vars.NEXT_PUBLIC_THIRDWEB_CLIENT_ID }}
           EXPO_PUBLIC_CHAIN_ID: "8453"
         run: eas build --platform ${{ matrix.platform }} --profile ${{ matrix.profile }} --non-interactive --no-wait

--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -4,9 +4,15 @@
 # URL of the deployed Next.js backend (no trailing slash)
 EXPO_PUBLIC_API_URL=http://localhost:3000
 
+# Canonical app URL/domain used in SIWE messages. For production builds these
+# should match web NEXT_PUBLIC_APP_URL and NEXT_PUBLIC_APP_DOMAIN.
+EXPO_PUBLIC_APP_URL=https://logadog.xyz
+EXPO_PUBLIC_APP_DOMAIN=logadog.xyz
+EXPO_PUBLIC_FARCASTER_SIWE_URI=https://logadog.xyz/login
+
 # Public Thirdweb client ID. Use the same value as the web app's
 # NEXT_PUBLIC_THIRDWEB_CLIENT_ID, then restart Expo after changing it.
 EXPO_PUBLIC_THIRDWEB_CLIENT_ID=
 
 # Chain ID: 8453 = Base mainnet, 84532 = Base Sepolia (testnet)
-EXPO_PUBLIC_CHAIN_ID=84532
+EXPO_PUBLIC_CHAIN_ID=8453

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -28,6 +28,9 @@ React Native app for [Log a Dog](https://logadog.xyz), sharing the backend and [
    | Variable | Description |
    |----------|-------------|
    | `EXPO_PUBLIC_API_URL` | Next.js backend URL (e.g. `https://logadog.xyz` or `http://localhost:3000`) |
+   | `EXPO_PUBLIC_APP_URL` | Canonical app URL used in SIWE messages (production: `https://logadog.xyz`) |
+   | `EXPO_PUBLIC_APP_DOMAIN` | Canonical app domain used in SIWE messages (production: `logadog.xyz`) |
+   | `EXPO_PUBLIC_FARCASTER_SIWE_URI` | Farcaster SIWE callback URI (production: `https://logadog.xyz/login`) |
    | `EXPO_PUBLIC_THIRDWEB_CLIENT_ID` | Public Thirdweb client ID (same value as web `NEXT_PUBLIC_THIRDWEB_CLIENT_ID`; restart Expo after changing it) |
    | `EXPO_PUBLIC_CHAIN_ID` | `8453` (Base mainnet) or `84532` (Base Sepolia) |
 
@@ -88,6 +91,7 @@ Merges to `main` submit fresh EAS preview builds through GitHub Actions:
 Required GitHub repository secrets:
 
 - `EXPO_TOKEN`: Expo access token for submitting EAS builds
+- `EXPO_PUBLIC_THIRDWEB_CLIENT_ID` or `NEXT_PUBLIC_THIRDWEB_CLIENT_ID`: same public Thirdweb client ID used by the web app
 
 Required EAS `preview` environment variable:
 

--- a/mobile/app/(tabs)/judge.tsx
+++ b/mobile/app/(tabs)/judge.tsx
@@ -149,11 +149,15 @@ export default function JudgeScreen() {
   const swipeX = useRef(new Animated.Value(0)).current;
 
   const panGesture = Gesture.Pan()
+    .runOnJS(true)
     .onUpdate((e) => {
       swipeX.setValue(e.translationX);
     })
     .onEnd((e) => {
-      if (!dog || !session) return;
+      if (!dog || !session || judgeMutation.isLoading) {
+        Animated.spring(swipeX, { toValue: 0, useNativeDriver: true }).start();
+        return;
+      }
       if (e.translationX > 80) {
         void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
         judgeMutation.mutate({

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -5,6 +5,7 @@ import { StatusBar } from "expo-status-bar";
 import { useFonts, Anton_400Regular } from "@expo-google-fonts/anton";
 import * as SplashScreen from "expo-splash-screen";
 import { useEffect } from "react";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { ThirdwebProvider } from "thirdweb/react";
 import { AuthProvider } from "~/providers/AuthProvider";
 import { WalletProvider } from "~/providers/WalletProvider";
@@ -24,106 +25,108 @@ export default function RootLayout() {
   if (!fontsLoaded) return null;
 
   return (
-    <ThirdwebProvider>
-      <AuthProvider>
-        <WalletProvider>
-          <TRPCProvider>
-          <StatusBar style="dark" />
-          <Stack>
-            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-            <Stack.Screen
-              name="dog/[logId]"
-              options={{
-                headerTitle: "Dog Details",
-                headerStyle: { backgroundColor: "#FFF8EC" },
-                headerTintColor: "#1E1A17",
-                headerTitleStyle: {
-                  fontFamily: "Anton_400Regular",
-                },
-              }}
-            />
-            <Stack.Screen
-              name="sign-in"
-              options={{
-                headerTitle: "Sign In",
-                headerStyle: { backgroundColor: "#FFF8EC" },
-                headerTintColor: "#1E1A17",
-                headerTitleStyle: {
-                  fontFamily: "Anton_400Regular",
-                },
-                presentation: "modal",
-              }}
-            />
-            <Stack.Screen
-              name="rules"
-              options={{
-                headerTitle: "How It Works",
-                headerStyle: { backgroundColor: "#FFF8EC" },
-                headerTintColor: "#1E1A17",
-                headerTitleStyle: {
-                  fontFamily: "Anton_400Regular",
-                },
-              }}
-            />
-            <Stack.Screen
-              name="faq"
-              options={{
-                headerTitle: "FAQ & Rules",
-                headerStyle: { backgroundColor: "#FFF8EC" },
-                headerTintColor: "#1E1A17",
-                headerTitleStyle: {
-                  fontFamily: "Anton_400Regular",
-                },
-              }}
-            />
-            <Stack.Screen
-              name="profile/address/[address]"
-              options={{
-                headerTitle: "Profile",
-                headerStyle: { backgroundColor: "#FFF8EC" },
-                headerTintColor: "#1E1A17",
-                headerTitleStyle: {
-                  fontFamily: "Anton_400Regular",
-                },
-              }}
-            />
-            <Stack.Screen
-              name="profile/[username]"
-              options={{
-                headerTitle: "Profile",
-                headerStyle: { backgroundColor: "#FFF8EC" },
-                headerTintColor: "#1E1A17",
-                headerTitleStyle: {
-                  fontFamily: "Anton_400Regular",
-                },
-              }}
-            />
-            <Stack.Screen
-              name="profile/id/[id]"
-              options={{
-                headerTitle: "Profile",
-                headerStyle: { backgroundColor: "#FFF8EC" },
-                headerTintColor: "#1E1A17",
-                headerTitleStyle: {
-                  fontFamily: "Anton_400Regular",
-                },
-              }}
-            />
-            <Stack.Screen
-              name="poidh"
-              options={{
-                headerTitle: "POIDH Campaign",
-                headerStyle: { backgroundColor: "#FFF8EC" },
-                headerTintColor: "#1E1A17",
-                headerTitleStyle: {
-                  fontFamily: "Anton_400Regular",
-                },
-              }}
-            />
-          </Stack>
-        </TRPCProvider>
-        </WalletProvider>
-      </AuthProvider>
-    </ThirdwebProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <ThirdwebProvider>
+        <AuthProvider>
+          <WalletProvider>
+            <TRPCProvider>
+              <StatusBar style="dark" />
+              <Stack>
+                <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+                <Stack.Screen
+                  name="dog/[logId]"
+                  options={{
+                    headerTitle: "Dog Details",
+                    headerStyle: { backgroundColor: "#FFF8EC" },
+                    headerTintColor: "#1E1A17",
+                    headerTitleStyle: {
+                      fontFamily: "Anton_400Regular",
+                    },
+                  }}
+                />
+                <Stack.Screen
+                  name="sign-in"
+                  options={{
+                    headerTitle: "Sign In",
+                    headerStyle: { backgroundColor: "#FFF8EC" },
+                    headerTintColor: "#1E1A17",
+                    headerTitleStyle: {
+                      fontFamily: "Anton_400Regular",
+                    },
+                    presentation: "modal",
+                  }}
+                />
+                <Stack.Screen
+                  name="rules"
+                  options={{
+                    headerTitle: "How It Works",
+                    headerStyle: { backgroundColor: "#FFF8EC" },
+                    headerTintColor: "#1E1A17",
+                    headerTitleStyle: {
+                      fontFamily: "Anton_400Regular",
+                    },
+                  }}
+                />
+                <Stack.Screen
+                  name="faq"
+                  options={{
+                    headerTitle: "FAQ & Rules",
+                    headerStyle: { backgroundColor: "#FFF8EC" },
+                    headerTintColor: "#1E1A17",
+                    headerTitleStyle: {
+                      fontFamily: "Anton_400Regular",
+                    },
+                  }}
+                />
+                <Stack.Screen
+                  name="profile/address/[address]"
+                  options={{
+                    headerTitle: "Profile",
+                    headerStyle: { backgroundColor: "#FFF8EC" },
+                    headerTintColor: "#1E1A17",
+                    headerTitleStyle: {
+                      fontFamily: "Anton_400Regular",
+                    },
+                  }}
+                />
+                <Stack.Screen
+                  name="profile/[username]"
+                  options={{
+                    headerTitle: "Profile",
+                    headerStyle: { backgroundColor: "#FFF8EC" },
+                    headerTintColor: "#1E1A17",
+                    headerTitleStyle: {
+                      fontFamily: "Anton_400Regular",
+                    },
+                  }}
+                />
+                <Stack.Screen
+                  name="profile/id/[id]"
+                  options={{
+                    headerTitle: "Profile",
+                    headerStyle: { backgroundColor: "#FFF8EC" },
+                    headerTintColor: "#1E1A17",
+                    headerTitleStyle: {
+                      fontFamily: "Anton_400Regular",
+                    },
+                  }}
+                />
+                <Stack.Screen
+                  name="poidh"
+                  options={{
+                    headerTitle: "POIDH Campaign",
+                    headerStyle: { backgroundColor: "#FFF8EC" },
+                    headerTintColor: "#1E1A17",
+                    headerTitleStyle: {
+                      fontFamily: "Anton_400Regular",
+                    },
+                  }}
+                />
+              </Stack>
+            </TRPCProvider>
+          </WalletProvider>
+        </AuthProvider>
+      </ThirdwebProvider>
+    </GestureHandlerRootView>
   );
 }

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -8,6 +8,9 @@
       "environment": "preview",
       "env": {
         "EXPO_PUBLIC_API_URL": "https://logadog.xyz",
+        "EXPO_PUBLIC_APP_URL": "https://logadog.xyz",
+        "EXPO_PUBLIC_APP_DOMAIN": "logadog.xyz",
+        "EXPO_PUBLIC_FARCASTER_SIWE_URI": "https://logadog.xyz/login",
         "EXPO_PUBLIC_CHAIN_ID": "8453"
       },
       "android": {
@@ -18,6 +21,9 @@
       "environment": "preview",
       "env": {
         "EXPO_PUBLIC_API_URL": "https://logadog.xyz",
+        "EXPO_PUBLIC_APP_URL": "https://logadog.xyz",
+        "EXPO_PUBLIC_APP_DOMAIN": "logadog.xyz",
+        "EXPO_PUBLIC_FARCASTER_SIWE_URI": "https://logadog.xyz/login",
         "EXPO_PUBLIC_CHAIN_ID": "8453"
       },
       "ios": {

--- a/mobile/src/constants/index.ts
+++ b/mobile/src/constants/index.ts
@@ -16,10 +16,29 @@ export {
 
 // ---- Mobile-only runtime config ----
 
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, "");
+
 export const API_URL =
-  (Constants.expoConfig?.extra?.apiUrl as string | undefined) ??
-  process.env.EXPO_PUBLIC_API_URL ??
-  "http://localhost:3000";
+  trimTrailingSlash(
+    (Constants.expoConfig?.extra?.apiUrl as string | undefined) ??
+      process.env.EXPO_PUBLIC_API_URL ??
+      "http://localhost:3000",
+  );
+
+export const APP_URL = trimTrailingSlash(
+  process.env.EXPO_PUBLIC_APP_URL ??
+    process.env.NEXT_PUBLIC_APP_URL ??
+    API_URL,
+);
+
+function getDomainFromUrl(url: string): string {
+  return url.replace(/^https?:\/\//, "").split("/")[0]?.split(":")[0] ?? "logadog.xyz";
+}
+
+export const APP_DOMAIN =
+  process.env.EXPO_PUBLIC_APP_DOMAIN ??
+  process.env.NEXT_PUBLIC_APP_DOMAIN ??
+  getDomainFromUrl(APP_URL);
 
 export const THIRDWEB_CLIENT_ID =
   process.env.EXPO_PUBLIC_THIRDWEB_CLIENT_ID ??
@@ -29,5 +48,7 @@ export const THIRDWEB_CLIENT_ID =
 export const CHAIN_ID = parseInt(process.env.EXPO_PUBLIC_CHAIN_ID ?? "8453", 10);
 
 export const FARCASTER_RELAY_URL = "https://relay.farcaster.xyz";
-export const FARCASTER_DOMAIN = "logadog.com";
-export const FARCASTER_SIWE_URI = "https://logadog.com";
+export const FARCASTER_DOMAIN =
+  process.env.EXPO_PUBLIC_FARCASTER_DOMAIN ?? APP_DOMAIN;
+export const FARCASTER_SIWE_URI =
+  process.env.EXPO_PUBLIC_FARCASTER_SIWE_URI ?? `${APP_URL}/login`;

--- a/mobile/src/providers/AuthProvider.tsx
+++ b/mobile/src/providers/AuthProvider.tsx
@@ -176,7 +176,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       nonce,
       domain: FARCASTER_DOMAIN,
       message,
-      signature,
+      signature: signature as `0x${string}`,
     });
 
     if (!verification.success) {

--- a/mobile/src/providers/AuthProvider.tsx
+++ b/mobile/src/providers/AuthProvider.tsx
@@ -11,6 +11,8 @@ import { createAppClient, viemConnector } from "@farcaster/auth-client";
 import { inAppWallet, type Account } from "thirdweb/wallets";
 import {
   API_URL,
+  APP_DOMAIN,
+  APP_URL,
   CHAIN_ID,
   FARCASTER_DOMAIN,
   FARCASTER_RELAY_URL,
@@ -40,16 +42,18 @@ const AuthContext = createContext<AuthContextValue>({
   signOut: async () => {},
 });
 
+type AuthProfile = Pick<Session, "fid" | "username" | "image" | "name">;
+
 async function createSiweMessage(address: string): Promise<string> {
   const nonce = Math.random().toString(36).slice(2);
   const issuedAt = new Date().toISOString();
   return [
-    `${FARCASTER_DOMAIN} wants you to sign in with your Ethereum account:`,
+    `${APP_DOMAIN} wants you to sign in with your Ethereum account:`,
     address,
     "",
     "Sign in to Log a Dog",
     "",
-    `URI: ${FARCASTER_SIWE_URI}`,
+    `URI: ${APP_URL}/login`,
     "Version: 1",
     `Chain ID: ${CHAIN_ID}`,
     `Nonce: ${nonce}`,
@@ -57,38 +61,37 @@ async function createSiweMessage(address: string): Promise<string> {
   ].join("\n");
 }
 
-async function postToNextAuth(
+async function postToMobileAuth(
   address: string,
   message: string,
   signature: string,
-): Promise<string> {
-  const csrfRes = await fetch(`${API_URL}/api/auth/csrf`);
-  if (!csrfRes.ok) throw new Error("Failed to fetch CSRF token");
-  const { csrfToken } = (await csrfRes.json()) as { csrfToken: string };
-
-  const signInRes = await fetch(`${API_URL}/api/auth/callback/credentials`, {
+  profile?: AuthProfile,
+): Promise<{ sessionToken: string; user: AuthProfile & { address: string } }> {
+  const signInRes = await fetch(`${API_URL}/api/mobile/auth/siwe`, {
     method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
       address,
       signature,
       message,
-      json: "true",
-    }).toString(),
-    redirect: "manual",
+      profile,
+    }),
   });
 
-  const rawCookies = signInRes.headers.get("set-cookie") ?? "";
-  const sessionTokenMatch = rawCookies.match(/next-auth\.session-token=([^;]+)/);
-  const sessionToken = sessionTokenMatch?.[1];
+  const payload = (await signInRes.json().catch(() => null)) as
+    | {
+        sessionToken?: string;
+        user?: AuthProfile & { address: string };
+        error?: string;
+      }
+    | null;
 
-  if (!sessionToken) {
+  if (!signInRes.ok || !payload?.sessionToken || !payload.user) {
     throw new Error(
-      "Authentication failed — could not retrieve session token. Ensure your signature is valid.",
+      payload?.error ?? "Authentication failed — could not retrieve session token. Ensure your signature is valid.",
     );
   }
-  return sessionToken;
+  return { sessionToken: payload.sessionToken, user: payload.user };
 }
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
@@ -110,18 +113,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const signInWithAccount = useCallback(
-    async (account: Account, profile?: Pick<Session, "fid" | "username" | "image" | "name">) => {
+    async (account: Account, profile?: AuthProfile) => {
       const message = await createSiweMessage(account.address);
       const signature = await account.signMessage({ message });
-      const sessionToken = await postToNextAuth(account.address, message, signature);
+      const { sessionToken, user } = await postToMobileAuth(account.address, message, signature, profile);
 
       await persistSession({
-        address: account.address.toLowerCase(),
+        address: user.address.toLowerCase(),
         sessionToken,
-        fid: profile?.fid ?? null,
-        username: profile?.username ?? null,
-        image: profile?.image ?? null,
-        name: profile?.name ?? null,
+        fid: profile?.fid ?? user.fid ?? null,
+        username: profile?.username ?? user.username ?? null,
+        image: profile?.image ?? user.image ?? null,
+        name: profile?.name ?? user.name ?? null,
       });
     },
     [persistSession],
@@ -157,26 +160,44 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     if (statusErr || !statusData) throw new Error("Sign-in timed out or was cancelled");
 
-    const { custody, signature, message, fid, username, displayName, pfpUrl } =
+    const { custody, signature, message, fid, username, displayName, pfpUrl, nonce } =
       statusData as {
         custody: string;
         signature: string;
         message: string;
+        nonce: string;
         fid?: number;
         username?: string;
         displayName?: string;
         pfpUrl?: string;
       };
 
-    const sessionToken = await postToNextAuth(custody, message, signature);
+    const verification = await appClient.verifySignInMessage({
+      nonce,
+      domain: FARCASTER_DOMAIN,
+      message,
+      signature,
+    });
 
-    await persistSession({
-      address: custody.toLowerCase(),
-      sessionToken,
+    if (!verification.success) {
+      throw new Error("Farcaster signature verification failed");
+    }
+
+    const profile = {
       fid: fid ?? null,
       username: username ?? null,
       image: pfpUrl ?? null,
       name: displayName ?? username ?? null,
+    };
+    const { sessionToken, user } = await postToMobileAuth(custody, message, signature, profile);
+
+    await persistSession({
+      address: user.address.toLowerCase(),
+      sessionToken,
+      fid: profile.fid ?? user.fid ?? null,
+      username: profile.username ?? user.username ?? null,
+      image: profile.image ?? user.image ?? null,
+      name: profile.name ?? user.name ?? null,
     });
   }, [persistSession]);
 

--- a/mobile/src/utils/trpc.ts
+++ b/mobile/src/utils/trpc.ts
@@ -19,7 +19,10 @@ export function buildTRPCClient(sessionToken?: string | null) {
         headers() {
           const headers: Record<string, string> = {};
           if (sessionToken) {
-            headers["Cookie"] = `next-auth.session-token=${sessionToken}`;
+            headers["Cookie"] = [
+              `next-auth.session-token=${sessionToken}`,
+              `__Secure-next-auth.session-token=${sessionToken}`,
+            ].join("; ");
           }
           return headers;
         },

--- a/src/pages/api/mobile/auth/siwe.ts
+++ b/src/pages/api/mobile/auth/siwe.ts
@@ -1,0 +1,88 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { encode } from "next-auth/jwt";
+import { z } from "zod";
+
+import {
+  AUTH_SESSION_MAX_AGE_SECONDS,
+  findOrCreateEthereumUser,
+} from "~/server/auth";
+import {
+  authenticateEthereumCredentials,
+  type AuthenticatedEthereumUser,
+} from "~/server/auth/ethereumProvider";
+
+const mobileSiweSchema = z.object({
+  address: z.string().min(1),
+  message: z.string().min(1),
+  signature: z.string().min(1),
+  profile: z
+    .object({
+      fid: z.number().optional().nullable(),
+      username: z.string().optional().nullable(),
+      image: z.string().optional().nullable(),
+      name: z.string().optional().nullable(),
+    })
+    .optional(),
+});
+
+type MobileSiweResponse =
+  | {
+      sessionToken: string;
+      user: AuthenticatedEthereumUser;
+    }
+  | {
+      error: string;
+    };
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<MobileSiweResponse>,
+) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const parsed = mobileSiweSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: "Invalid SIWE payload" });
+  }
+
+  const authenticatedUser = await authenticateEthereumCredentials(
+    parsed.data,
+    findOrCreateEthereumUser,
+  );
+
+  if (!authenticatedUser) {
+    return res.status(401).json({ error: "Invalid signature" });
+  }
+
+  const secret = process.env.NEXTAUTH_SECRET;
+  if (!secret) {
+    return res.status(500).json({ error: "NEXTAUTH_SECRET is not configured" });
+  }
+
+  const profile = parsed.data.profile;
+  const user = {
+    ...authenticatedUser,
+    fid: profile?.fid ?? authenticatedUser.fid,
+    username: profile?.username ?? authenticatedUser.username,
+    image: profile?.image ?? authenticatedUser.image,
+    name: profile?.name ?? authenticatedUser.name,
+  };
+
+  const sessionToken = await encode({
+    secret,
+    maxAge: AUTH_SESSION_MAX_AGE_SECONDS,
+    token: {
+      sub: user.id,
+      id: user.id,
+      address: user.address,
+      fid: user.fid,
+      name: user.name,
+      picture: user.image,
+    },
+  });
+
+  return res.status(200).json({ sessionToken, user });
+}

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -6,6 +6,7 @@ import {
   type NextAuthOptions,
 } from "next-auth";
 import { type Adapter } from "next-auth/adapters";
+import { type User } from "@prisma/client";
 import { EthereumProvider } from "~/server/auth/ethereumProvider";
 
 import { db } from "~/server/db";
@@ -49,6 +50,143 @@ declare module "next-auth/jwt" {
   }
 }
 
+export const AUTH_SESSION_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
+
+export async function findOrCreateEthereumUser(credentials: {
+  address: string;
+}): Promise<User> {
+  let fid: number | undefined;
+  let username: string | undefined;
+  let name: string | undefined;
+  let image: string | undefined;
+  try {
+    // Fetch user's FID from Neynar using their Ethereum address
+    const response = await neynarClient.fetchBulkUsersByEthOrSolAddress({
+      addresses: [credentials.address],
+    });
+
+    // Extract FID from response - fixing the access pattern
+    const addressKey = credentials.address.toLowerCase();
+    fid = response[addressKey]?.[0]?.fid;
+    username = response[addressKey]?.[0]?.username;
+    name = response[addressKey]?.[0]?.display_name;
+    image = response[addressKey]?.[0]?.pfp_url;
+  } catch (error) {
+    console.error("Error fetching FID from Neynar:", error);
+  }
+
+  // Helper function for database operations with retries
+  const withRetry = async <T>(operation: () => Promise<T>, context: string): Promise<T> => {
+    let retries = 3;
+    while (retries > 0) {
+      try {
+        return await operation();
+      } catch (dbError: unknown) {
+        console.error(`Database operation failed in ${context} (${4 - retries}/3):`, dbError);
+        retries--;
+        if (retries === 0) {
+          throw dbError;
+        }
+        // Wait 1 second before retrying
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      }
+    }
+    throw new Error("Unexpected end of retry loop");
+  };
+
+  // First try to find existing user by address (upserts would fail if the user already exists)
+  let user = await withRetry(
+    () => db.user.findFirst({
+      where: {
+        address: credentials.address.toLowerCase(),
+      },
+    }),
+    'findFirst user'
+  );
+
+  if (user) {
+    // Update existing user
+    const userId = user.id; // Capture the ID to avoid null reference issues
+    user = await withRetry(
+      () => db.user.update({
+        where: {
+          id: userId,
+        },
+        data: {
+          fid,
+          username,
+          image,
+          name,
+        },
+      }),
+      'update user'
+    );
+  } else {
+    // Create new user
+    user = await withRetry(
+      () => db.user.create({
+        data: {
+          address: credentials.address.toLowerCase(),
+          fid,
+          username,
+          image,
+          name,
+        },
+      }),
+      'create user'
+    );
+  }
+
+  // Link any existing DogEvents to this user
+  try {
+    const finalUserId = user.id; // Capture user ID to avoid null reference issues
+    const unlinkedEvents = await withRetry(
+      () => db.dogEvent.updateMany({
+        where: {
+          eater: credentials.address.toLowerCase(),
+          userId: null,
+        },
+        data: {
+          userId: finalUserId,
+        },
+      }),
+      'update dog events'
+    );
+
+    if (unlinkedEvents.count > 0) {
+      console.log(`Linked ${unlinkedEvents.count} historical DogEvents to user ${user.id}`);
+    }
+  } catch (error) {
+    console.error('Error linking historical DogEvents:', error);
+    // Don't fail auth if this fails
+  }
+
+  // Create a new account for the user
+  const accountUserId = user.id; // Capture user ID to avoid null reference issues
+  await withRetry(
+    () => db.account.upsert({
+      where: {
+        provider_providerAccountId: {
+          provider: "ethereum",
+          providerAccountId: credentials.address,
+        },
+      },
+      update: {
+        type: "ethereum",
+      },
+      create: {
+        userId: accountUserId,
+        type: "ethereum",
+        provider: "ethereum",
+        providerAccountId: credentials.address,
+      },
+    }),
+    'upsert account'
+  );
+  console.log(' returning user ');
+  return user;
+}
+
 /**
  * Options for NextAuth.js used to configure adapters, providers, callbacks, etc.
  *
@@ -58,7 +196,7 @@ export const authOptions: NextAuthOptions = {
   session: {
     strategy: "jwt",
     // Keep users signed in across mini-app opens without re-prompting for SIWE.
-    maxAge: 30 * 24 * 60 * 60,
+    maxAge: AUTH_SESSION_MAX_AGE_SECONDS,
   },
   callbacks: {
     async jwt({ token, user }) {
@@ -100,138 +238,7 @@ export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(db) as Adapter,
   providers: [
     EthereumProvider({
-      async createUser(credentials) {
-        let fid: number | undefined;
-        let username: string | undefined;
-        let name: string | undefined;
-        let image: string | undefined;
-        try {
-          // Fetch user's FID from Neynar using their Ethereum address
-          const response = await neynarClient.fetchBulkUsersByEthOrSolAddress({
-            addresses: [credentials.address],
-          });
-
-          // Extract FID from response - fixing the access pattern
-          const addressKey = credentials.address.toLowerCase();
-          fid = response[addressKey]?.[0]?.fid;
-          username = response[addressKey]?.[0]?.username;
-          name = response[addressKey]?.[0]?.display_name;
-          image = response[addressKey]?.[0]?.pfp_url;
-        } catch (error) {
-          console.error("Error fetching FID from Neynar:", error);
-        }
-
-        // Helper function for database operations with retries
-        const withRetry = async <T>(operation: () => Promise<T>, context: string): Promise<T> => {
-          let retries = 3;
-          while (retries > 0) {
-            try {
-              return await operation();
-            } catch (dbError: unknown) {
-              console.error(`Database operation failed in ${context} (${4 - retries}/3):`, dbError);
-              retries--;
-              if (retries === 0) {
-                throw dbError;
-              }
-              // Wait 1 second before retrying
-              await new Promise(resolve => setTimeout(resolve, 1000));
-            }
-          }
-          throw new Error("Unexpected end of retry loop");
-        };
-
-        // First try to find existing user by address (upserts would fail if the user already exists)
-        let user = await withRetry(
-          () => db.user.findFirst({
-            where: {
-              address: credentials.address.toLowerCase(),
-            },
-          }),
-          'findFirst user'
-        );
-
-        if (user) {
-          // Update existing user
-          const userId = user.id; // Capture the ID to avoid null reference issues
-          user = await withRetry(
-            () => db.user.update({
-              where: {
-                id: userId,
-              },
-              data: {
-                fid,
-                username,
-                image,
-                name,
-              },
-            }),
-            'update user'
-          );
-        } else {
-          // Create new user
-          user = await withRetry(
-            () => db.user.create({
-              data: {
-                address: credentials.address.toLowerCase(),
-                fid,
-                username,
-                image,
-                name,
-              },
-            }),
-            'create user'
-          );
-        }
-
-        // Link any existing DogEvents to this user
-        try {
-          const finalUserId = user.id; // Capture user ID to avoid null reference issues
-          const unlinkedEvents = await withRetry(
-            () => db.dogEvent.updateMany({
-              where: {
-                eater: credentials.address.toLowerCase(),
-                userId: null,
-              },
-              data: {
-                userId: finalUserId,
-              },
-            }),
-            'update dog events'
-          );
-          
-          if (unlinkedEvents.count > 0) {
-            console.log(`Linked ${unlinkedEvents.count} historical DogEvents to user ${user.id}`);
-          }
-        } catch (error) {
-          console.error('Error linking historical DogEvents:', error);
-          // Don't fail auth if this fails
-        }
-
-        // Create a new account for the user
-        const accountUserId = user.id; // Capture user ID to avoid null reference issues
-        await withRetry(
-          () => db.account.upsert({ 
-            where: {
-              provider_providerAccountId: {
-                provider: "ethereum",
-                providerAccountId: credentials.address,
-              },
-            },
-            update: {
-              type: "ethereum",
-            },
-            create: {
-              userId: accountUserId,
-              type: "ethereum",
-              provider: "ethereum",
-              providerAccountId: credentials.address,
-            },
-          }),
-          'upsert account'
-        );
-        console.log(' returning user ');
-        return user;
-      },
+      createUser: findOrCreateEthereumUser,
     }),
     /**
      * ...add more providers here.

--- a/src/server/auth/ethereumProvider.ts
+++ b/src/server/auth/ethereumProvider.ts
@@ -7,6 +7,209 @@ import { db } from "~/server/db";
 type EthereumProviderConfig = {
   createUser: (credentials: { address: string }) => Promise<User>;
 }
+
+export type EthereumCredentials = {
+  address: string;
+  message: string;
+  signature: string;
+};
+
+export type AuthenticatedEthereumUser = {
+  id: string;
+  address: string;
+  fid?: number;
+  username?: string;
+  image?: string;
+  name?: string;
+};
+
+export async function authenticateEthereumCredentials(
+  credentials: EthereumCredentials | undefined,
+  createUser: EthereumProviderConfig["createUser"],
+): Promise<AuthenticatedEthereumUser | null> {
+  console.log('Authorize called with credentials:', credentials);
+  if (!credentials?.message || !credentials?.signature || !credentials?.address) {
+    console.log('Missing credentials');
+    return null;
+  }
+
+  // Helper function for database operations with retries
+  const withRetry = async <T>(operation: () => Promise<T>, context: string): Promise<T> => {
+    let retries = 3;
+    while (retries > 0) {
+      try {
+        return await operation();
+      } catch (dbError: unknown) {
+        console.error(`Database operation failed in ${context} (${4 - retries}/3):`, dbError);
+        retries--;
+        if (retries === 0) {
+          throw dbError;
+        }
+        // Wait 1 second before retrying
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      }
+    }
+    throw new Error("Unexpected end of retry loop");
+  };
+
+  try {
+    const isValid = await verifySignature(
+      credentials.message,
+      credentials.signature,
+      credentials.address as `0x${string}`,
+    );
+
+    if (isValid) {
+      console.log('Signature is valid');
+
+      const walletAddress = credentials.address.toLowerCase(); // Capture address to avoid undefined issues
+
+      // if the credentials.message includes "Link User:", we can extract the user id
+      const linkUserRegex = /Link User: ([a-zA-Z0-9]+)/;
+      // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
+      const linkUserMatch = credentials.message.match(linkUserRegex);;
+      const linkUser = linkUserMatch ? linkUserMatch[1] : undefined;
+      // user is linking their ethereum address to an existing account
+      if (linkUser) {
+        return linkAddressToExistingUser({
+          existingUserId: linkUser,
+          credentials,
+          withRetry,
+        });
+      }
+
+      // Use retry logic for database connection issues
+      let user = await withRetry(
+        () => db.user.findFirst({
+          where: { address: walletAddress },
+        }),
+        'find user by address'
+      );
+
+      if (!user) {
+        console.log('Creating new user');
+        user = await createUser({ address: walletAddress });
+      }
+
+      console.log('Returning user:', user);
+      return {
+        id: user.id,
+        address: walletAddress,
+        fid: user.fid ?? undefined,
+        username: user.username ?? undefined,
+        image: user.image ?? undefined,
+        name: user.name ?? undefined,
+      }
+    }
+
+    console.error("Signature verification failed")
+    return null
+  } catch (error) {
+    console.error("Error in authorize:", error)
+    return null
+  }
+}
+
+async function linkAddressToExistingUser({
+  existingUserId,
+  credentials,
+  withRetry,
+}: {
+  existingUserId: string;
+  credentials: EthereumCredentials;
+  withRetry: <T>(operation: () => Promise<T>, context: string) => Promise<T>;
+}): Promise<AuthenticatedEthereumUser | null> {
+  if (!credentials.address) return null;
+
+  const walletAddress = credentials.address.toLowerCase(); // Capture address to avoid undefined issues
+
+  // check if the user who is trying to link (the ethereum wallet that signed)
+  // has already linked an ethereum address
+  const ethereumWalletUser = await withRetry(
+    () => db.user.findFirst({
+      where: {
+        address: walletAddress,
+      },
+    }),
+    'find ethereum wallet user'
+  );
+  // if the user has already linked an ethereum address to another user,
+  // we should remove the link before linking to the new user
+  //
+  // this can happen if the user signs in as a guest and connects their wallet
+  // then the come back later and try to connect their ethereum wallet to another
+  // guest account. We should remove the link to the first guest account.
+
+  // delete the existing link
+  if (ethereumWalletUser) {
+    await withRetry(
+      () => db.user.update({
+        where: {
+          id: ethereumWalletUser.id,
+        },
+        data: {
+          address: null,
+        },
+      }),
+      'update ethereum wallet user'
+    );
+    // delete the associated ethereum account
+    await withRetry(
+      () => db.account.deleteMany({
+        where: {
+          userId: ethereumWalletUser.id,
+          type: "ethereum",
+        },
+      }),
+      'delete ethereum accounts'
+    );
+  }
+
+  const existingLinkedUser = await withRetry(
+    () => db.user.findUnique({
+      where: {
+        id: existingUserId,
+      },
+    }),
+    'find existing linked user'
+  );
+  if (existingLinkedUser?.address) {
+    console.error("User already has an ethereum address linked")
+    return null;
+  }
+  const user = await withRetry(
+    () => db.user.update({
+      where: {
+        id: existingUserId,
+      },
+      data: {
+        address: walletAddress,
+      },
+    }),
+    'update user with address'
+  );
+  await withRetry(
+    () => db.account.create({
+      data: {
+        userId: user.id,
+        type: "ethereum",
+        provider: "ethereum",
+        providerAccountId: walletAddress,
+      },
+    }),
+    'create ethereum account'
+  );
+
+  return {
+    id: user.id,
+    address: walletAddress,
+    fid: user.fid ?? undefined,
+    username: user.username ?? undefined,
+    image: user.image ?? undefined,
+    name: user.name ?? undefined,
+  }
+}
+
 export const EthereumProvider = ({ createUser }: EthereumProviderConfig): NextAuthOptions["providers"][number] => ({
   id: "ethereum",
   name: "Ethereum",
@@ -17,172 +220,6 @@ export const EthereumProvider = ({ createUser }: EthereumProviderConfig): NextAu
     address: { label: "Address", type: "text" },
   },
   async authorize(credentials) {
-    console.log('Authorize called with credentials:', credentials);
-    if (!credentials?.message || !credentials?.signature || !credentials?.address) {
-      console.log('Missing credentials');
-      return null;
-    }
-
-    // Helper function for database operations with retries
-    const withRetry = async <T>(operation: () => Promise<T>, context: string): Promise<T> => {
-      let retries = 3;
-      while (retries > 0) {
-        try {
-          return await operation();
-        } catch (dbError: unknown) {
-          console.error(`Database operation failed in ${context} (${4 - retries}/3):`, dbError);
-          retries--;
-          if (retries === 0) {
-            throw dbError;
-          }
-          // Wait 1 second before retrying
-          await new Promise(resolve => setTimeout(resolve, 1000));
-        }
-      }
-      throw new Error("Unexpected end of retry loop");
-    };
-
-    try {
-      const isValid = await verifySignature(
-        credentials.message,
-        credentials.signature,
-        credentials.address as `0x${string}`,
-      );
-
-      if (isValid) {
-        console.log('Signature is valid');
-        
-        const walletAddress = credentials.address.toLowerCase(); // Capture address to avoid undefined issues
-        
-        // if the credentials.message includes "Link User:", we can extract the user id
-        const linkUserRegex = /Link User: ([a-zA-Z0-9]+)/;
-        // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
-        const linkUserMatch = credentials.message.match(linkUserRegex);;
-        const linkUser = linkUserMatch ? linkUserMatch[1] : undefined;
-        // user is linking their ethereum address to an existing account
-        if (linkUser) {
-          return linkAddressToExistingUser({
-            existingUserId: linkUser,
-            withRetry
-          });
-        }
-
-        // Use retry logic for database connection issues
-        let user = await withRetry(
-          () => db.user.findFirst({
-            where: { address: walletAddress },
-          }),
-          'find user by address'
-        );
-
-        if (!user) {
-          console.log('Creating new user');
-          user = await createUser({ address: walletAddress });
-        }
-
-        console.log('Returning user:', user);
-        return {
-          id: user.id,
-          address: walletAddress,
-        }
-      }
-
-      console.error("Signature verification failed")
-      return null
-    } catch (error) {
-      console.error("Error in authorize:", error)
-      return null
-    }
-
-    async function linkAddressToExistingUser({ existingUserId, withRetry }: { 
-      existingUserId: string;
-      withRetry: <T>(operation: () => Promise<T>, context: string) => Promise<T>;
-    }) {
-      if (!credentials?.address) return null;
-      
-      const walletAddress = credentials.address.toLowerCase(); // Capture address to avoid undefined issues
-
-      // check if the user who is trying to link (the ethereum wallet that signed)
-      // has already linked an ethereum address
-      const ethereumWalletUser = await withRetry(
-        () => db.user.findFirst({
-          where: {
-            address: walletAddress,
-          },
-        }),
-        'find ethereum wallet user'
-      );
-      // if the user has already linked an ethereum address to another user,
-      // we should remove the link before linking to the new user
-      // 
-      // this can happen if the user signs in as a guest and connects their wallet
-      // then the come back later and try to connect their ethereum wallet to another
-      // guest account. We should remove the link to the first guest account. 
-      
-      // delete the existing link
-      if (ethereumWalletUser) {
-        await withRetry(
-          () => db.user.update({
-            where: {
-              id: ethereumWalletUser.id,
-            },
-            data: {
-              address: null,
-            },
-          }),
-          'update ethereum wallet user'
-        );
-        // delete the associated ethereum account
-        await withRetry(
-          () => db.account.deleteMany({
-            where: {
-              userId: ethereumWalletUser.id,
-              type: "ethereum",
-            },
-          }),
-          'delete ethereum accounts'
-        );
-      }
-
-      const existingLinkedUser = await withRetry(
-        () => db.user.findUnique({
-          where: {
-            id: existingUserId,
-          },
-        }),
-        'find existing linked user'
-      );
-      if (existingLinkedUser?.address) {
-        console.error("User already has an ethereum address linked")
-        return null;
-      }
-      const user = await withRetry(
-        () => db.user.update({
-          where: {
-            id: existingUserId,
-          },
-          data: {
-            address: walletAddress,
-          },
-        }),
-        'update user with address'
-      );
-      await withRetry(
-        () => db.account.create({
-          data: {
-            userId: user.id,
-            type: "ethereum",
-            provider: "ethereum",
-            providerAccountId: walletAddress,
-          },
-        }),
-        'create ethereum account'
-      );
-
-      return {
-        id: user.id,
-        address: walletAddress,
-      }
-    }
+    return authenticateEthereumCredentials(credentials, createUser);
   },
 });

--- a/src/server/auth/ethereumProvider.ts
+++ b/src/server/auth/ethereumProvider.ts
@@ -220,6 +220,17 @@ export const EthereumProvider = ({ createUser }: EthereumProviderConfig): NextAu
     address: { label: "Address", type: "text" },
   },
   async authorize(credentials) {
-    return authenticateEthereumCredentials(credentials, createUser);
+    if (!credentials?.address || !credentials.message || !credentials.signature) {
+      return authenticateEthereumCredentials(undefined, createUser);
+    }
+
+    return authenticateEthereumCredentials(
+      {
+        address: credentials.address,
+        message: credentials.message,
+        signature: credentials.signature,
+      },
+      createUser,
+    );
   },
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Wrap the native app in `GestureHandlerRootView` and run judge swipe handlers on the JS thread.
- Add a mobile SIWE auth endpoint that returns a NextAuth-compatible JWT in JSON for React Native.
- Update mobile auth constants, tRPC cookie forwarding, and EAS/GitHub env wiring for Farcaster and Thirdweb sign-in.

### Testing
- `bun run typecheck`
- `bun run build:api-types`
- `cd mobile && bun run typecheck`
- `SKIP_ENV_VALIDATION=true NEXT_PUBLIC_THIRDWEB_CLIENT_ID=dummy-client-id bun run build`
- `SKIP_ENV_VALIDATION=true NEXT_PUBLIC_THIRDWEB_CLIENT_ID=dummy-client-id bun run lint`
- Built-server smoke test for `/api/mobile/auth/siwe` validation responses (`GET` -> 405, empty `POST` -> 400).

### Manual testing note
- Expo web smoke test was attempted but blocked because the mobile project does not include `react-native-web`; no native simulator is available in this Cloud Agent environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1f44-97a7-7535-8645-6f4d7d96f772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1f44-97a7-7535-8645-6f4d7d96f772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

