### PR TITLE
Fix native wallet and Farcaster auth links

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,66 @@
       <category android:name="android.intent.category.BROWSABLE"/>
       <data android:scheme="https"/>
     </intent>
+    <intent>
+      <action android:name="android.intent.action.VIEW"/>
+      <category android:name="android.intent.category.BROWSABLE"/>
+      <data android:scheme="farcaster"/>
+    </intent>
+    <intent>
+      <action android:name="android.intent.action.VIEW"/>
+      <category android:name="android.intent.category.BROWSABLE"/>
+      <data android:scheme="warpcast"/>
+    </intent>
+    <intent>
+      <action android:name="android.intent.action.VIEW"/>
+      <category android:name="android.intent.category.BROWSABLE"/>
+      <data android:scheme="wc"/>
+    </intent>
+    <intent>
+      <action android:name="android.intent.action.VIEW"/>
+      <category android:name="android.intent.category.BROWSABLE"/>
+      <data android:scheme="metamask"/>
+    </intent>
+    <intent>
+      <action android:name="android.intent.action.VIEW"/>
+      <category android:name="android.intent.category.BROWSABLE"/>
+      <data android:scheme="trust"/>
+    </intent>
+    <intent>
+      <action android:name="android.intent.action.VIEW"/>
+      <category android:name="android.intent.category.BROWSABLE"/>
+      <data android:scheme="rainbow"/>
+    </intent>
+    <intent>
+      <action android:name="android.intent.action.VIEW"/>
+      <category android:name="android.intent.category.BROWSABLE"/>
+      <data android:scheme="uniswap"/>
+    </intent>
+    <intent>
+      <action android:name="android.intent.action.VIEW"/>
+      <category android:name="android.intent.category.BROWSABLE"/>
+      <data android:scheme="zerion"/>
+    </intent>
+    <intent>
+      <action android:name="android.intent.action.VIEW"/>
+      <category android:name="android.intent.category.BROWSABLE"/>
+      <data android:scheme="imtokenv2"/>
+    </intent>
+    <intent>
+      <action android:name="android.intent.action.VIEW"/>
+      <category android:name="android.intent.category.BROWSABLE"/>
+      <data android:scheme="argent"/>
+    </intent>
+    <intent>
+      <action android:name="android.intent.action.VIEW"/>
+      <category android:name="android.intent.category.BROWSABLE"/>
+      <data android:scheme="safe"/>
+    </intent>
+    <intent>
+      <action android:name="android.intent.action.VIEW"/>
+      <category android:name="android.intent.category.BROWSABLE"/>
+      <data android:scheme="cbwallet"/>
+    </intent>
   </queries>
   <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="true" android:theme="@style/AppTheme" android:supportsRtl="true" android:fullBackupContent="@xml/secure_store_backup_rules" android:dataExtractionRules="@xml/secure_store_data_extraction_rules">
     <meta-data android:name="expo.modules.updates.ENABLED" android:value="false"/>

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -19,7 +19,21 @@
       "newArchEnabled": false,
       "infoPlist": {
         "NSPhotoLibraryUsageDescription": "Log a Dog needs access to your photos to submit a hotdog.",
-        "NSCameraUsageDescription": "Log a Dog needs your camera to snap a hotdog pic."
+        "NSCameraUsageDescription": "Log a Dog needs your camera to snap a hotdog pic.",
+        "LSApplicationQueriesSchemes": [
+          "farcaster",
+          "warpcast",
+          "wc",
+          "metamask",
+          "trust",
+          "rainbow",
+          "uniswap",
+          "zerion",
+          "imtokenv2",
+          "argent",
+          "safe",
+          "cbwallet"
+        ]
       }
     },
     "android": {
@@ -58,6 +72,88 @@
             "extraMavenRepos": [
               "https://www.jitpack.io"
             ],
+            "manifestQueries": {
+              "intent": [
+                {
+                  "action": "android.intent.action.VIEW",
+                  "data": {
+                    "scheme": "https"
+                  }
+                },
+                {
+                  "action": "android.intent.action.VIEW",
+                  "data": {
+                    "scheme": "farcaster"
+                  }
+                },
+                {
+                  "action": "android.intent.action.VIEW",
+                  "data": {
+                    "scheme": "warpcast"
+                  }
+                },
+                {
+                  "action": "android.intent.action.VIEW",
+                  "data": {
+                    "scheme": "wc"
+                  }
+                },
+                {
+                  "action": "android.intent.action.VIEW",
+                  "data": {
+                    "scheme": "metamask"
+                  }
+                },
+                {
+                  "action": "android.intent.action.VIEW",
+                  "data": {
+                    "scheme": "trust"
+                  }
+                },
+                {
+                  "action": "android.intent.action.VIEW",
+                  "data": {
+                    "scheme": "rainbow"
+                  }
+                },
+                {
+                  "action": "android.intent.action.VIEW",
+                  "data": {
+                    "scheme": "uniswap"
+                  }
+                },
+                {
+                  "action": "android.intent.action.VIEW",
+                  "data": {
+                    "scheme": "zerion"
+                  }
+                },
+                {
+                  "action": "android.intent.action.VIEW",
+                  "data": {
+                    "scheme": "imtokenv2"
+                  }
+                },
+                {
+                  "action": "android.intent.action.VIEW",
+                  "data": {
+                    "scheme": "argent"
+                  }
+                },
+                {
+                  "action": "android.intent.action.VIEW",
+                  "data": {
+                    "scheme": "safe"
+                  }
+                },
+                {
+                  "action": "android.intent.action.VIEW",
+                  "data": {
+                    "scheme": "cbwallet"
+                  }
+                }
+              ]
+            },
             "packagingOptions": {
               "pickFirst": [
                 "**/libc++_shared.so",

--- a/mobile/index.js
+++ b/mobile/index.js
@@ -1,3 +1,5 @@
-// Must be imported first — provides React Native polyfills for Thirdweb v5
+// Must be imported first — provides React Native polyfills for WalletConnect.
+import "@walletconnect/react-native-compat";
+// Provides React Native polyfills for Thirdweb v5.
 import "@thirdweb-dev/react-native-adapter";
 import "expo-router/entry";

--- a/mobile/ios/LogaDog/Info.plist
+++ b/mobile/ios/LogaDog/Info.plist
@@ -34,6 +34,21 @@
     </array>
     <key>CFBundleVersion</key>
     <string>1</string>
+    <key>LSApplicationQueriesSchemes</key>
+    <array>
+      <string>farcaster</string>
+      <string>warpcast</string>
+      <string>wc</string>
+      <string>metamask</string>
+      <string>trust</string>
+      <string>rainbow</string>
+      <string>uniswap</string>
+      <string>zerion</string>
+      <string>imtokenv2</string>
+      <string>argent</string>
+      <string>safe</string>
+      <string>cbwallet</string>
+    </array>
     <key>LSMinimumSystemVersion</key>
     <string>12.0</string>
     <key>LSRequiresIPhoneOS</key>

--- a/mobile/src/providers/AuthProvider.tsx
+++ b/mobile/src/providers/AuthProvider.tsx
@@ -6,7 +6,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { Alert, Linking } from "react-native";
+import { Linking } from "react-native";
 import { createAppClient, viemConnector } from "@farcaster/auth-client";
 import { inAppWallet, type Account } from "thirdweb/wallets";
 import {
@@ -94,6 +94,16 @@ async function postToMobileAuth(
   return { sessionToken: payload.sessionToken, user: payload.user };
 }
 
+async function openFarcasterAuthUrl(url: string) {
+  try {
+    await Linking.openURL(url);
+  } catch {
+    throw new Error(
+      `Could not open Warpcast. Install Warpcast and try again, or paste this URL in Warpcast: ${url}`,
+    );
+  }
+}
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -145,12 +155,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     const { url, channelToken } = channelData;
 
-    const canOpen = await Linking.canOpenURL(url);
-    if (canOpen) {
-      await Linking.openURL(url);
-    } else {
-      Alert.alert("Open Warpcast", `Paste this URL in Warpcast:\n\n${url}`);
-    }
+    await openFarcasterAuthUrl(url);
 
     const { data: statusData, isError: statusErr } = await appClient.watchStatus({
       channelToken,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Initialize WalletConnect's React Native compatibility shim before Thirdweb startup code.
- Open Farcaster auth URLs directly instead of blocking on native `canOpenURL` false negatives.
- Add iOS and Android URL-query visibility for Farcaster, WalletConnect, and common wallet schemes.

### Validation
- `bun run typecheck` from `mobile`
- `bun x expo config --json` verified iOS and Android scheme query config
- `git diff --check`
- `SKIP_ENV_VALIDATION=true bun run build` compiled successfully but stopped at page-data collection because Thirdweb credentials are not present in this environment (`clientId or secretKey must be provided`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1f76-cf69-7601-8c68-f2583669b71a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1f76-cf69-7601-8c68-f2583669b71a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

