### PR TITLE
Fix mobile wallet sign-in, IPFS upload, and earn/nav UI bugs

### DIFF
--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -82,9 +82,12 @@ function CustomTabBar({ state, navigation }: TabBarProps) {
                     transform: [{ scale: pressed ? 0.9 : 1 }],
                   })}
                 >
+                  {/* Rounded on the image itself: expo-image is a native view
+                      that the container's overflow:hidden doesn't reliably
+                      clip, which rendered the FAB as a square. */}
                   <Image
                     source={require("../../assets/icon.png")}
-                    style={{ width: 60, height: 60 }}
+                    style={{ width: 56, height: 56, borderRadius: 28 }}
                     contentFit="cover"
                   />
                 </Pressable>

--- a/mobile/app/(tabs)/earn.tsx
+++ b/mobile/app/(tabs)/earn.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { Pressable, ScrollView, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
@@ -20,7 +20,6 @@ export default function EarnScreen() {
   const { session } = useAuth();
   const router = useRouter();
   const season = getSeasonInfo();
-  const [tab, setTab] = useState<"stake" | "claim">("stake");
   // The stake/claim/airdrop panels create a Thirdweb client at render time,
   // which throws if the build is missing the public client ID — guard so a
   // misconfigured build degrades to a message instead of crashing the tab.
@@ -73,35 +72,13 @@ export default function EarnScreen() {
         <RelevantHolders />
 
         {walletReady ? (
+          // Every earn action is a self-titled card; stacking them avoids the
+          // ambiguous stake/claim page toggle that read as action buttons.
           <>
-            <View className="flex-row gap-2 mb-4">
-              {(["stake", "claim"] as const).map((t) => (
-                <Pressable
-                  key={t}
-                  onPress={() => setTab(t)}
-                  className={`flex-1 rounded-xl py-2 items-center ${tab === t ? "bg-primary" : "bg-base-200"}`}
-                  style={{ borderWidth: 2.5, borderColor: INK }}
-                >
-                  <Text
-                    className={`font-display text-sm capitalize tracking-wide ${tab === t ? "text-neutral" : "text-neutral/60"}`}
-                  >
-                    {t}
-                  </Text>
-                </Pressable>
-              ))}
-            </View>
-
-            {tab === "stake" ? (
-              <>
-                <StakePanel />
-                <AirdropPanel />
-              </>
-            ) : (
-              <>
-                <ClaimRewardsPanel />
-                <ClaimProtocolRewardsPanel />
-              </>
-            )}
+            <StakePanel />
+            <AirdropPanel />
+            <ClaimRewardsPanel />
+            <ClaimProtocolRewardsPanel />
           </>
         ) : (
           <View className="bg-error/10 border border-error/30 rounded-2xl p-4 mb-4">

--- a/mobile/app/sign-in.tsx
+++ b/mobile/app/sign-in.tsx
@@ -65,7 +65,7 @@ export default function SignInScreen() {
       const account = wallet?.getAccount();
       if (!account) return;
 
-      setLoadingLabel("Signing in…");
+      setLoadingLabel("Confirm sign-in in your wallet…");
       await signInWithWallet(account);
       navigate();
     } catch (err) {

--- a/mobile/src/components/ui/Pop.tsx
+++ b/mobile/src/components/ui/Pop.tsx
@@ -12,6 +12,10 @@ import { COLORS } from "~/constants/colors";
 // (globals.css): thick ink outlines + hard offset shadows with no blur.
 // React Native can't render blur-free offset box-shadows cross-platform, so
 // the shadow is a solid ink layer positioned behind the bordered content.
+// The shadow layer is pinned with edge insets rather than width/height
+// percentages: percentage sizes on absolute children of shrink-wrapped
+// (auto-width) parents mis-resolve on the new architecture and can paint a
+// full-screen ink band (seen behind centered buttons like "Buy $HOTDOG").
 
 export const INK = COLORS.neutral;
 
@@ -44,8 +48,8 @@ export function PopCard({
           position: "absolute",
           top: offset,
           left: offset,
-          width: "100%",
-          height: "100%",
+          right: -offset,
+          bottom: -offset,
           borderRadius: radius,
           backgroundColor: INK,
         }}
@@ -89,8 +93,8 @@ export function PopSticker({
           position: "absolute",
           top: offset,
           left: offset,
-          width: "100%",
-          height: "100%",
+          right: -offset,
+          bottom: -offset,
           borderRadius: radius,
           backgroundColor: INK,
         }}
@@ -143,8 +147,8 @@ export function PopButton({
           position: "absolute",
           top: offset,
           left: offset,
-          width: "100%",
-          height: "100%",
+          right: -offset,
+          bottom: -offset,
           borderRadius: radius,
           backgroundColor: INK,
           opacity: disabled ? 0.35 : 1,

--- a/mobile/src/providers/AuthProvider.tsx
+++ b/mobile/src/providers/AuthProvider.tsx
@@ -6,7 +6,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { Linking } from "react-native";
+import { AppState, Linking } from "react-native";
 import { createAppClient, viemConnector } from "@farcaster/auth-client";
 import { inAppWallet, type Account } from "thirdweb/wallets";
 import {
@@ -92,6 +92,27 @@ async function postToMobileAuth(
     );
   }
   return { sessionToken: payload.sessionToken, user: payload.user };
+}
+
+/**
+ * Resolves once this app is in the foreground. Right after a WalletConnect
+ * pairing is approved the user is still inside their wallet app; firing the
+ * SIWE sign request while we're backgrounded means the OS blocks the deep
+ * link back into the wallet and the signature prompt never appears.
+ */
+async function waitForAppForeground(): Promise<void> {
+  if (AppState.currentState !== "active") {
+    await new Promise<void>((resolve) => {
+      const sub = AppState.addEventListener("change", (state) => {
+        if (state === "active") {
+          sub.remove();
+          resolve();
+        }
+      });
+    });
+    // Let the app-switch transition settle before deep-linking back out.
+    await new Promise((resolve) => setTimeout(resolve, 750));
+  }
 }
 
 async function openFarcasterAuthUrl(url: string) {
@@ -254,7 +275,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const signInWithWallet = useCallback(
     async (account: Account) => {
-      await signInWithAccount(account);
+      // External wallets sign over WalletConnect: wait until we're back in the
+      // foreground so the personal_sign request can deep-link to the wallet.
+      await waitForAppForeground();
+      try {
+        await signInWithAccount(account);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "";
+        if (msg.includes("Failed to open URI")) {
+          throw new Error(
+            "We couldn't reopen your wallet automatically. Open your wallet app, approve the pending sign-in request, then return here and try again.",
+          );
+        }
+        throw err;
+      }
     },
     [signInWithAccount],
   );

--- a/mobile/src/utils/upload.ts
+++ b/mobile/src/utils/upload.ts
@@ -1,17 +1,17 @@
-import { upload } from "thirdweb/storage";
+import { uploadMobile } from "thirdweb/storage";
 import { getThirdwebClient } from "~/utils/thirdweb";
 
-export async function uploadImageToIPFS(localUri: string): Promise<string> {
-  const response = await fetch(localUri);
-  const blob = await response.blob();
+// thirdweb's `upload()` only supports browser/node and throws
+// "Please, use the uploadMobile function in mobile environments." in React
+// Native, so both helpers must go through `uploadMobile`.
 
-  // thirdweb/storage `upload` supports Blob/File in React Native via the adapter
-  const uris = await upload({
+export async function uploadImageToIPFS(localUri: string): Promise<string> {
+  const uris = await uploadMobile({
     client: getThirdwebClient(),
-    files: [new File([blob], "hotdog.jpg", { type: "image/jpeg" })],
+    files: [{ name: "hotdog.jpg", type: "image/jpeg", uri: localUri }],
   });
 
-  const uri = Array.isArray(uris) ? uris[0] : uris;
+  const uri = uris[0];
   if (!uri) throw new Error("Upload returned no URI");
   return uri;
 }
@@ -21,12 +21,12 @@ export async function uploadMetadataToIPFS(metadata: {
   description: string;
   image: string;
 }): Promise<string> {
-  const uris = await upload({
+  const uris = await uploadMobile({
     client: getThirdwebClient(),
     files: [metadata],
   });
 
-  const uri = Array.isArray(uris) ? uris[0] : uris;
+  const uri = uris[0];
   if (!uri) throw new Error("Metadata upload returned no URI");
   return uri;
 }


### PR DESCRIPTION
- Wallet sign-in: wait for the app to return to the foreground before
  sending the SIWE personal_sign request. Right after the WalletConnect
  pairing is approved the user is still in their wallet app, so the
  deep link back to the wallet was blocked by the OS and the "Sign in
  with Ethereum" prompt never appeared. Also guide the user with a
  "Confirm sign-in in your wallet" label and a clearer error when the
  wallet app can't be reopened automatically.
- Image upload: thirdweb's `upload()` only supports browser/node and
  throws "Please, use the uploadMobile function in mobile environments"
  in React Native. Use `uploadMobile` for both image and metadata
  uploads.
- Pop shadows: pin the hard-shadow layer with edge insets instead of
  width/height percentages, which mis-resolve for shrink-wrapped
  (centered) buttons and painted a full-screen black band behind the
  "Buy $HOTDOG" button.
- Earn page: remove the outer Stake/Claim toggle that read as action
  buttons and duplicated the in-card controls; stack the self-titled
  Stake, Airdrop, Claim Rewards, and Creator Rewards cards instead.
- Tab bar: round the center hotdog image itself (expo-image isn't
  reliably clipped by the container's overflow:hidden) so the log
  button renders as a circle inside its black border.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CXbxAhhoPKnRTrYqPrPenH