### PR TITLE
Fix mobile image resolution, sign-in copy, Apple login, and holders layout

### DIFF
--- a/mobile/app/(tabs)/earn.tsx
+++ b/mobile/app/(tabs)/earn.tsx
@@ -132,7 +132,7 @@ export default function EarnScreen() {
           >
             <Text className="font-bold text-neutral mb-1">Sign in to earn</Text>
             <Text className="text-neutral/60 text-sm mb-3">
-              Connect with Farcaster to log dogs and earn $HOTDOG tokens.
+              Sign in to log dogs and earn $HOTDOG tokens.
             </Text>
             <PopButton
               onPress={() => router.push("/sign-in")}

--- a/mobile/app/(tabs)/judge.tsx
+++ b/mobile/app/(tabs)/judge.tsx
@@ -20,7 +20,8 @@ import { AiJudgement } from "~/components/AiJudgement";
 import { VotingCountdown } from "~/components/VotingCountdown";
 import { ProfileAvatar } from "~/components/ProfileAvatar";
 import { COLORS } from "~/constants/colors";
-import { convertIpfsToHttps, formatTimestamp, getDisplayName } from "~/utils/format";
+import { formatTimestamp, getDisplayName } from "~/utils/format";
+import { resolveHotdogImage } from "~/utils/hotdogImage";
 import { isJudgeable } from "@shared/time";
 import { useJudges, useUserVotes } from "~/hooks/useHotdogs";
 import type { ProcessedHotdog } from "~/types";
@@ -190,8 +191,9 @@ export default function JudgeScreen() {
     );
   }
 
-  const imageUri = convertIpfsToHttps(
-    dog?.zoraCoin?.mediaContent?.previewImage?.medium ?? dog?.imageUri,
+  const imageUri = resolveHotdogImage(
+    dog?.zoraCoin?.mediaContent?.previewImage?.medium,
+    dog?.imageUri,
   );
   const eaterName = getDisplayName(dog?.eaterProfile, dog?.eater ?? "");
   const imageHeight = Math.round((width - 32) * (5 / 4));

--- a/mobile/app/(tabs)/profile.tsx
+++ b/mobile/app/(tabs)/profile.tsx
@@ -24,14 +24,14 @@ export default function ProfileScreen() {
           JOIN THE GAME
         </Text>
         <Text className="text-neutral/60 text-center text-base mb-8">
-          Sign in with Farcaster to log dogs, vote, and climb the leaderboard.
+          Sign in to log dogs, vote, and climb the leaderboard.
         </Text>
         <Pressable
           onPress={() => router.push("/sign-in")}
           className="bg-primary rounded-2xl px-8 py-4 w-full items-center"
         >
           <Text className="font-display text-neutral text-lg tracking-wider">
-            SIGN IN WITH FARCASTER
+            SIGN IN
           </Text>
         </Pressable>
       </SafeAreaView>

--- a/mobile/app/dog/[logId].tsx
+++ b/mobile/app/dog/[logId].tsx
@@ -23,11 +23,8 @@ import { RevokeButton } from "~/components/RevokeButton";
 import { ZoraStatsFlip } from "~/components/ZoraStatsFlip";
 import { COLORS } from "~/constants/colors";
 import { formatAbbreviatedFiat } from "@shared/format";
-import {
-  convertIpfsToHttps,
-  formatTimestamp,
-  getDisplayName,
-} from "~/utils/format";
+import { formatTimestamp, getDisplayName } from "~/utils/format";
+import { resolveHotdogImage } from "~/utils/hotdogImage";
 import { useAuth } from "~/providers/AuthProvider";
 import { useHotdog } from "~/hooks/useHotdogs";
 
@@ -80,8 +77,9 @@ export default function DogDetailScreen() {
     );
   }
 
-  const imageUri = convertIpfsToHttps(
-    hotdog.zoraCoin?.mediaContent?.previewImage?.medium ?? hotdog.imageUri,
+  const imageUri = resolveHotdogImage(
+    hotdog.zoraCoin?.mediaContent?.previewImage?.medium,
+    hotdog.imageUri,
   );
   const eaterName = getDisplayName(hotdog.eaterProfile, hotdog.eater);
   const loggerName = getDisplayName(hotdog.loggerProfile, hotdog.logger);

--- a/mobile/app/sign-in.tsx
+++ b/mobile/app/sign-in.tsx
@@ -21,7 +21,13 @@ import { PopButton } from "~/components/ui/Pop";
 type Mode = "choose" | "email" | "email-verify";
 
 export default function SignInScreen() {
-  const { signInWithFarcaster, signInWithEmail, signInWithGoogle, signInWithWallet } = useAuth();
+  const {
+    signInWithFarcaster,
+    signInWithEmail,
+    signInWithGoogle,
+    signInWithApple,
+    signInWithWallet,
+  } = useAuth();
   const { connectExternalWallet } = useWallet();
   const router = useRouter();
   const [mode, setMode] = useState<Mode>("choose");
@@ -56,6 +62,9 @@ export default function SignInScreen() {
 
   const handleGoogle = () =>
     wrap("Signing in with Google…", signInWithGoogle);
+
+  const handleApple = () =>
+    wrap("Signing in with Apple…", signInWithApple);
 
   const handleWallet = async () => {
     setIsLoading(true);
@@ -254,6 +263,35 @@ export default function SignInScreen() {
             )}
           </PopButton>
 
+          {Platform.OS === "ios" && (
+            <PopButton
+              onPress={handleApple}
+              disabled={isLoading}
+              radius={16}
+              backgroundColor={COLORS.neutral}
+              contentStyle={{ paddingVertical: 14, alignItems: "center" }}
+            >
+              {isLoading && loadingLabel.includes("Apple") ? (
+                <View className="flex-row items-center gap-3">
+                  <ActivityIndicator color={COLORS.base100} size="small" />
+                  <Text
+                    className="font-bold"
+                    style={{ color: COLORS.base100 }}
+                  >
+                    {loadingLabel}
+                  </Text>
+                </View>
+              ) : (
+                <Text
+                  className="font-bold text-base"
+                  style={{ color: COLORS.base100 }}
+                >
+                  🍎 Continue with Apple
+                </Text>
+              )}
+            </PopButton>
+          )}
+
           <PopButton
             onPress={handleGoogle}
             disabled={isLoading}
@@ -288,7 +326,7 @@ export default function SignInScreen() {
 
         <Text className="text-neutral/40 text-xs text-center leading-5">
           Mobile uses native wallet connections instead of the web-only Thirdweb modal.
-          Google and email create a Thirdweb in-app wallet.
+          Apple, Google, and email create a Thirdweb in-app wallet.
         </Text>
       </ScrollView>
     </SafeAreaView>

--- a/mobile/src/components/HotdogCard.tsx
+++ b/mobile/src/components/HotdogCard.tsx
@@ -10,11 +10,8 @@ import { VotingCountdown } from "~/components/VotingCountdown";
 import { PopCard, PopSticker, INK } from "~/components/ui/Pop";
 import { COLORS } from "~/constants/colors";
 import { ATTESTATION_WINDOW_SECONDS } from "~/constants";
-import {
-  convertIpfsToHttps,
-  formatTimestamp,
-  getDisplayName,
-} from "~/utils/format";
+import { formatTimestamp, getDisplayName } from "~/utils/format";
+import { resolveHotdogImage } from "~/utils/hotdogImage";
 import type { ProcessedHotdog } from "~/types";
 
 interface Props {
@@ -54,9 +51,9 @@ export function HotdogCard({
 
   const imageUri = useMemo(
     () =>
-      convertIpfsToHttps(
-        hotdog.zoraCoin?.mediaContent?.previewImage?.medium ??
-          hotdog.imageUri,
+      resolveHotdogImage(
+        hotdog.zoraCoin?.mediaContent?.previewImage?.medium,
+        hotdog.imageUri,
       ),
     [hotdog.zoraCoin, hotdog.imageUri],
   );

--- a/mobile/src/components/earn/RelevantHolders.tsx
+++ b/mobile/src/components/earn/RelevantHolders.tsx
@@ -6,6 +6,10 @@ import { useAuth } from "~/providers/AuthProvider";
 import { trpc } from "~/utils/trpc";
 import { HOTDOG_TOKEN } from "~/constants/addresses";
 import { CHAIN_ID } from "~/constants";
+import { COLORS } from "~/constants/colors";
+
+const AVATAR_SIZE = 40;
+const AVATAR_OVERLAP = 12;
 
 export function RelevantHolders() {
   const { session } = useAuth();
@@ -33,24 +37,44 @@ export function RelevantHolders() {
   const remaining = holders.length - visible.length;
 
   return (
-    <View className="items-center mb-4">
-      <View className="flex-row">
-        {visible.map((h) => (
+    <View className="items-center bg-base-200 rounded-2xl px-4 py-4 mb-4">
+      <View className="flex-row flex-wrap justify-center">
+        {visible.map((h: any, i: number) => (
           <Pressable
             key={h.fid}
             onPress={() =>
               router.push(`/profile/address/${h.custody_address}`)
             }
-            className="-ml-2"
+            style={{
+              marginLeft: i === 0 ? 0 : -AVATAR_OVERLAP,
+              zIndex: visible.length - i,
+            }}
           >
             <Image
               source={{ uri: h.pfp_url }}
-              style={{ width: 40, height: 40, borderRadius: 20, borderWidth: 2, borderColor: "#FFF8EC" }}
+              style={{
+                width: AVATAR_SIZE,
+                height: AVATAR_SIZE,
+                borderRadius: AVATAR_SIZE / 2,
+                borderWidth: 2,
+                borderColor: COLORS.base200,
+              }}
             />
           </Pressable>
         ))}
         {remaining > 0 && (
-          <View className="w-10 h-10 rounded-full bg-neutral items-center justify-center -ml-2">
+          <View
+            className="bg-neutral items-center justify-center"
+            style={{
+              width: AVATAR_SIZE,
+              height: AVATAR_SIZE,
+              borderRadius: AVATAR_SIZE / 2,
+              borderWidth: 2,
+              borderColor: COLORS.base200,
+              marginLeft: -AVATAR_OVERLAP,
+              zIndex: 0,
+            }}
+          >
             <Text className="text-white text-xs font-bold">+{remaining}</Text>
           </View>
         )}

--- a/mobile/src/providers/AuthProvider.tsx
+++ b/mobile/src/providers/AuthProvider.tsx
@@ -28,6 +28,7 @@ interface AuthContextValue {
   signInWithFarcaster: () => Promise<void>;
   signInWithEmail: (email: string) => Promise<{ requiresVerification: true; verify: (code: string) => Promise<void> } | void>;
   signInWithGoogle: () => Promise<void>;
+  signInWithApple: () => Promise<void>;
   signInWithWallet: (account: Account) => Promise<void>;
   signOut: () => Promise<void>;
 }
@@ -38,6 +39,7 @@ const AuthContext = createContext<AuthContextValue>({
   signInWithFarcaster: async () => {},
   signInWithEmail: async () => {},
   signInWithGoogle: async () => {},
+  signInWithApple: async () => {},
   signInWithWallet: async () => {},
   signOut: async () => {},
 });
@@ -273,6 +275,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     await signInWithAccount(account);
   }, [signInWithAccount]);
 
+  const signInWithApple = useCallback(async () => {
+    const wallet = inAppWallet();
+    const thirdwebClient = getThirdwebClient();
+    const account = await wallet.connect({
+      client: thirdwebClient,
+      // @ts-ignore - chain type compatibility
+      chain: getThirdwebChain(),
+      strategy: "apple",
+      redirectUrl: "logadog://",
+    });
+
+    await signInWithAccount(account);
+  }, [signInWithAccount]);
+
   const signInWithWallet = useCallback(
     async (account: Account) => {
       // External wallets sign over WalletConnect: wait until we're back in the
@@ -299,8 +315,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const value = useMemo(
-    () => ({ session, isLoading, signInWithFarcaster, signInWithEmail, signInWithGoogle, signInWithWallet, signOut }),
-    [session, isLoading, signInWithFarcaster, signInWithEmail, signInWithGoogle, signInWithWallet, signOut],
+    () => ({ session, isLoading, signInWithFarcaster, signInWithEmail, signInWithGoogle, signInWithApple, signInWithWallet, signOut }),
+    [session, isLoading, signInWithFarcaster, signInWithEmail, signInWithGoogle, signInWithApple, signInWithWallet, signOut],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/mobile/src/utils/hotdogImage.ts
+++ b/mobile/src/utils/hotdogImage.ts
@@ -1,0 +1,31 @@
+import { resolveScheme } from "thirdweb/storage";
+import { convertIpfsToHttps } from "@shared/format";
+import { getThirdwebClient, isThirdwebConfigured } from "~/utils/thirdweb";
+
+/**
+ * Resolve a hotdog's display image. Prefers the Zora coin's cached preview
+ * image; falls back to the raw upload. A freshly logged dog has no Zora coin
+ * media yet (indexing lag), so it falls back to `imageUri` — a thirdweb-hosted
+ * `ipfs://` URI. That only resolves reliably through thirdweb's own gateway
+ * (same infra that received the upload); a generic public gateway like
+ * ipfs.io often hasn't picked up the content yet, which is why the newest
+ * log's photo showed up on web (thirdweb `MediaRenderer`/`resolveScheme`) but
+ * not on mobile (plain `ipfs://` -> `ipfs.io` string swap).
+ */
+export function resolveHotdogImage(
+  preview: string | null | undefined,
+  rawImageUri: string | null | undefined,
+): string | null {
+  if (preview) return convertIpfsToHttps(preview);
+  if (!rawImageUri) return null;
+
+  if (rawImageUri.startsWith("ipfs://") && isThirdwebConfigured()) {
+    try {
+      return resolveScheme({ client: getThirdwebClient(), uri: rawImageUri });
+    } catch {
+      return convertIpfsToHttps(rawImageUri);
+    }
+  }
+
+  return convertIpfsToHttps(rawImageUri);
+}


### PR DESCRIPTION
- Resolve freshly logged dogs' images via thirdweb's own gateway
  (resolveScheme) instead of a public ipfs.io swap, which often hasn't
  picked up a thirdweb-hosted upload yet — this is why the newest log's
  photo showed on web (which already uses thirdweb resolution) but not
  in the app.
- Generalize the "sign in" copy on the profile/earn empty states so it
  doesn't imply Farcaster is the only option.
- Add Sign in with Apple (thirdweb inAppWallet "apple" strategy),
  required alongside Google/email for App Store review.
- Fix the "friends holding $HOTDOG" avatar row on the earn page:
  explicit z-index stacking, no stray negative margin on the first
  avatar, wrapped in a proper padded card so it can't visually overflow.