### PR TITLE
Fix mobile nav Log FAB: circular hotdog with black outline

### DIFF
--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -14,6 +14,12 @@ interface TabBarProps {
 }
 
 // Mirrors the web BottomNav: Feed · Leaderboard · [raised Log button] · Judge · You
+const LOG_FAB_SIZE = 64;
+const LOG_FAB_BORDER = 4;
+const LOG_FAB_INNER = LOG_FAB_SIZE - LOG_FAB_BORDER * 2;
+/** Half the FAB height — pops the circle above the nav's top ink rule (web: -mt-8). */
+const LOG_FAB_RAISE = LOG_FAB_SIZE / 2;
+
 const TAB_CONFIG = [
   { name: "index", icon: "🌭", label: "Feed" },
   { name: "leaderboard", icon: "🏆", label: "Leaderboard" },
@@ -72,30 +78,45 @@ function CustomTabBar({ state, navigation }: TabBarProps) {
                 style={{
                   flex: 1,
                   alignItems: "center",
-                  justifyContent: "center",
+                  justifyContent: "flex-end",
                   overflow: "visible",
                   zIndex: 10,
                 }}
               >
                 <Pressable
                   onPress={onPress}
+                  accessibilityRole="button"
+                  accessibilityLabel="Log a dog"
                   style={({ pressed }) => ({
-                    width: 64,
-                    height: 64,
-                    borderRadius: 32,
-                    borderWidth: 4,
-                    borderColor: COLORS.neutral,
-                    overflow: "hidden",
-                    marginTop: -32,
+                    marginTop: -LOG_FAB_RAISE,
                     zIndex: 10,
                     transform: [{ scale: pressed ? 0.9 : 1 }],
                   })}
                 >
-                  <Image
-                    source={require("../../assets/hotdog-icon.png")}
-                    style={{ width: 64, height: 64 }}
-                    contentFit="cover"
-                  />
+                  <View
+                    style={{
+                      width: LOG_FAB_SIZE,
+                      height: LOG_FAB_SIZE,
+                      borderRadius: LOG_FAB_SIZE / 2,
+                      borderWidth: LOG_FAB_BORDER,
+                      borderColor: COLORS.neutral,
+                      alignItems: "center",
+                      justifyContent: "center",
+                      backgroundColor: COLORS.base100,
+                    }}
+                  >
+                    {/* expo-image is a native view; parent overflow:hidden does not
+                        reliably clip it, so round the image itself. */}
+                    <Image
+                      source={require("../../assets/hotdog-icon.png")}
+                      style={{
+                        width: LOG_FAB_INNER,
+                        height: LOG_FAB_INNER,
+                        borderRadius: LOG_FAB_INNER / 2,
+                      }}
+                      contentFit="cover"
+                    />
+                  </View>
                 </Pressable>
               </View>
             );
@@ -168,6 +189,10 @@ export default function TabLayout() {
           fontFamily: "Segment-Bold",
           letterSpacing: 1,
           fontSize: 17,
+        },
+        tabBarStyle: {
+          overflow: "visible",
+          elevation: 0,
         },
       }}
     >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the native mobile app's center Log button in the bottom nav to match the web design:

- **Circular shape** — applies `borderRadius` directly on the `expo-image` view (parent `overflow: hidden` does not reliably clip native image views, which caused the square FAB seen in the screenshot)
- **Black outline** — 4px ring using `COLORS.neutral` (`#1E1A17`), matching web `border-4 border-base-content`
- **Raised pop** — shifts the FAB up by half its height (`-32px`) so the top of the circle extends above the nav's top ink rule

## Changes

- `mobile/app/(tabs)/_layout.tsx`
  - Extract FAB sizing constants (`LOG_FAB_SIZE`, `LOG_FAB_BORDER`, `LOG_FAB_RAISE`)
  - Split border ring and image into separate views for reliable rendering
  - Set `tabBarStyle.overflow: 'visible'` to prevent Android clipping of the raised button
  - Add accessibility label for the Log action

## Test plan

- [ ] Open the mobile app on iOS simulator/device
- [ ] Verify center hotdog button is circular with a visible black border
- [ ] Verify the top of the circle pops above the bottom nav separator line
- [ ] Tap the button — Log modal should open with press scale animation
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2073-6cf4-70ce-8bd4-89b94d83edd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2073-6cf4-70ce-8bd4-89b94d83edd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

