### PR TITLE
Fix Farcaster sign-in on native mobile app

### DIFF
--- a/mobile/app/sign-in.tsx
+++ b/mobile/app/sign-in.tsx
@@ -58,7 +58,7 @@ export default function SignInScreen() {
   };
 
   const handleFarcaster = () =>
-    wrap("Opening Warpcast…", signInWithFarcaster);
+    wrap("Opening Farcaster…", signInWithFarcaster);
 
   const handleGoogle = () =>
     wrap("Signing in with Google…", signInWithGoogle);
@@ -251,7 +251,7 @@ export default function SignInScreen() {
             backgroundColor={COLORS.base200}
             contentStyle={{ paddingVertical: 14, alignItems: "center" }}
           >
-            {isLoading && loadingLabel.includes("Warpcast") ? (
+            {isLoading && loadingLabel.includes("Farcaster") ? (
               <View className="flex-row items-center gap-3">
                 <ActivityIndicator color={COLORS.neutral} size="small" />
                 <Text className="font-bold text-neutral">{loadingLabel}</Text>

--- a/mobile/src/providers/AuthProvider.tsx
+++ b/mobile/src/providers/AuthProvider.tsx
@@ -7,7 +7,11 @@ import React, {
   useState,
 } from "react";
 import { AppState, Linking } from "react-native";
-import { createAppClient, viemConnector } from "@farcaster/auth-client";
+import {
+  createAppClient,
+  type AppClient,
+  viemConnector,
+} from "@farcaster/auth-client";
 import { inAppWallet, type Account } from "thirdweb/wallets";
 import {
   API_URL,
@@ -117,14 +121,78 @@ async function waitForAppForeground(): Promise<void> {
   }
 }
 
-async function openFarcasterAuthUrl(url: string) {
+function buildFarcasterConnectUrl(channelToken: string, nonce: string): string {
+  const params = new URLSearchParams({
+    channelToken,
+    nonce,
+    siweUri: FARCASTER_SIWE_URI,
+    domain: FARCASTER_DOMAIN,
+  });
+  return `farcaster://connect?${params.toString()}`;
+}
+
+async function openFarcasterAuthUrl(
+  channelToken: string,
+  nonce: string,
+  relayUrl: string,
+) {
+  const deepLink = buildFarcasterConnectUrl(channelToken, nonce);
+  let url = relayUrl;
+
+  try {
+    const canOpenDeepLink = await Linking.canOpenURL(deepLink);
+    if (canOpenDeepLink) url = deepLink;
+  } catch {
+    // canOpenURL can fail on some Android builds — fall back to relay URL.
+  }
+
   try {
     await Linking.openURL(url);
   } catch {
     throw new Error(
-      `Could not open Warpcast. Install Warpcast and try again, or paste this URL in Warpcast: ${url}`,
+      `Could not open Farcaster. Install the Farcaster app and try again, or paste this URL in Farcaster: ${relayUrl}`,
     );
   }
+}
+
+type FarcasterAuthStatus = NonNullable<
+  Awaited<ReturnType<AppClient["status"]>>["data"]
+>;
+
+/**
+ * Poll the Farcaster auth relay until sign-in completes. Unlike watchStatus,
+ * this survives app backgrounding: network failures while the user is in
+ * Warpcast are retried, and the timeout only counts foreground time.
+ */
+async function watchFarcasterAuthStatus(
+  appClient: AppClient,
+  channelToken: string,
+): Promise<FarcasterAuthStatus> {
+  const TIMEOUT_MS = 300_000;
+  const INTERVAL_MS = 1_500;
+  let remainingMs = TIMEOUT_MS;
+
+  while (remainingMs > 0) {
+    // Don't burn the timeout while the user is in the Farcaster app.
+    while (AppState.currentState !== "active") {
+      await waitForAppForeground();
+    }
+
+    const tickStart = Date.now();
+    const { data, isError } = await appClient.status({ channelToken });
+
+    if (!isError && data?.state === "completed") {
+      return data;
+    }
+
+    remainingMs -= Date.now() - tickStart;
+    if (remainingMs <= 0) break;
+
+    await new Promise((resolve) => setTimeout(resolve, INTERVAL_MS));
+    remainingMs -= INTERVAL_MS;
+  }
+
+  throw new Error("Sign-in timed out or was cancelled");
 }
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
@@ -176,17 +244,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     if (isError || !channelData) throw new Error("Failed to create Farcaster auth channel");
 
-    const { url, channelToken } = channelData;
+    const { url, channelToken, nonce: channelNonce } = channelData;
 
-    await openFarcasterAuthUrl(url);
+    await openFarcasterAuthUrl(channelToken, channelNonce, url);
 
-    const { data: statusData, isError: statusErr } = await appClient.watchStatus({
-      channelToken,
-      timeout: 300_000,
-      interval: 1_500,
-    });
-
-    if (statusErr || !statusData) throw new Error("Sign-in timed out or was cancelled");
+    const statusData = await watchFarcasterAuthStatus(appClient, channelToken);
 
     const { custody, signature, message, fid, username, displayName, pfpUrl, nonce } =
       statusData as {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Tapping **Sign in with Farcaster** on the native app immediately showed:

> Sign-in timed out or was cancelled

This happened because the app opened the Farcaster client (backgrounding Log a Dog) while `@farcaster/auth-client`'s `watchStatus` was polling the relay. When iOS/Android suspend background network activity, the in-flight poll fails and the client treats it as a terminal error.

## Fix

- Replace `watchStatus` with a **background-aware poll** using `appClient.status()`:
  - Waits for the app to return to the foreground before continuing
  - Does not count background time against the 5-minute timeout
  - Retries relay/network errors instead of failing immediately
- Open the Farcaster app via **`farcaster://connect?...` deep link** when installed (falls back to the relay HTTPS URL)
- Update loading copy to "Opening Farcaster…"

## Test plan

- [ ] On iOS device/simulator with Farcaster installed: tap Sign in with Farcaster → approve in Farcaster → return to app → session created
- [ ] On Android device with Farcaster installed: same flow
- [ ] Without Farcaster installed: verify fallback URL error message is helpful
- [ ] Cancel sign-in in Farcaster: verify timeout message after waiting

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2086-b8c1-77b7-94c9-0cc9a15dd86f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2086-b8c1-77b7-94c9-0cc9a15dd86f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

